### PR TITLE
Lab 2 data model, migrations, and seed

### DIFF
--- a/server/prisma/migrations/20260904150857_add_active_to_category/migration.sql
+++ b/server/prisma/migrations/20260904150857_add_active_to_category/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Category" ADD COLUMN     "active" BOOLEAN NOT NULL DEFAULT true;

--- a/server/prisma/migrations/20260904150907_lab2_core_models/migration.sql
+++ b/server/prisma/migrations/20260904150907_lab2_core_models/migration.sql
@@ -1,0 +1,120 @@
+-- CreateEnum
+CREATE TYPE "Priority" AS ENUM ('LOW', 'MEDIUM', 'HIGH', 'URGENT');
+
+-- CreateEnum
+CREATE TYPE "TicketStatus" AS ENUM ('NEW');
+
+-- CreateEnum
+CREATE TYPE "Role" AS ENUM ('REQUESTER', 'STAFF', 'ADMIN');
+
+-- CreateTable
+CREATE TABLE "RelatedSystem" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "RelatedSystem_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "RequesterUser" (
+    "id" SERIAL NOT NULL,
+    "fullName" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "department" TEXT,
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    "role" "Role" NOT NULL DEFAULT 'REQUESTER',
+    "passwordHash" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "RequesterUser_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Ticket" (
+    "id" SERIAL NOT NULL,
+    "ticketNumber" TEXT NOT NULL,
+    "requesterId" INTEGER NOT NULL,
+    "categoryId" INTEGER NOT NULL,
+    "relatedSystemId" INTEGER NOT NULL,
+    "requestedPriority" "Priority" NOT NULL,
+    "summary" VARCHAR(200) NOT NULL,
+    "description" TEXT NOT NULL,
+    "currentStatus" "TicketStatus" NOT NULL DEFAULT 'NEW',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Ticket_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Attachment" (
+    "id" SERIAL NOT NULL,
+    "ticketId" INTEGER NOT NULL,
+    "originalFilename" TEXT NOT NULL,
+    "storedFilename" TEXT NOT NULL,
+    "mimeType" TEXT NOT NULL,
+    "sizeBytes" INTEGER NOT NULL,
+    "uploadedByRequesterId" INTEGER NOT NULL,
+    "uploadedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "removedAt" TIMESTAMP(3),
+    "removedByRequesterId" INTEGER,
+    "removalReason" TEXT,
+
+    CONSTRAINT "Attachment_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TicketCounter" (
+    "year" INTEGER NOT NULL,
+    "lastValue" INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT "TicketCounter_pkey" PRIMARY KEY ("year")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RelatedSystem_name_key" ON "RelatedSystem"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "RequesterUser_email_key" ON "RequesterUser"("email");
+
+-- CreateIndex
+CREATE INDEX "RequesterUser_active_idx" ON "RequesterUser"("active");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Ticket_ticketNumber_key" ON "Ticket"("ticketNumber");
+
+-- CreateIndex
+CREATE INDEX "Ticket_requesterId_createdAt_idx" ON "Ticket"("requesterId", "createdAt");
+
+-- CreateIndex
+CREATE INDEX "Ticket_requesterId_categoryId_idx" ON "Ticket"("requesterId", "categoryId");
+
+-- CreateIndex
+CREATE INDEX "Ticket_requesterId_relatedSystemId_idx" ON "Ticket"("requesterId", "relatedSystemId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Attachment_storedFilename_key" ON "Attachment"("storedFilename");
+
+-- CreateIndex
+CREATE INDEX "Attachment_ticketId_removedAt_idx" ON "Attachment"("ticketId", "removedAt");
+
+-- AddForeignKey
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_requesterId_fkey" FOREIGN KEY ("requesterId") REFERENCES "RequesterUser"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_categoryId_fkey" FOREIGN KEY ("categoryId") REFERENCES "Category"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Ticket" ADD CONSTRAINT "Ticket_relatedSystemId_fkey" FOREIGN KEY ("relatedSystemId") REFERENCES "RelatedSystem"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Attachment" ADD CONSTRAINT "Attachment_ticketId_fkey" FOREIGN KEY ("ticketId") REFERENCES "Ticket"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Attachment" ADD CONSTRAINT "Attachment_uploadedByRequesterId_fkey" FOREIGN KEY ("uploadedByRequesterId") REFERENCES "RequesterUser"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Attachment" ADD CONSTRAINT "Attachment_removedByRequesterId_fkey" FOREIGN KEY ("removedByRequesterId") REFERENCES "RequesterUser"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -10,10 +10,129 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-// ---------------------------------------------------------------------------
+// --- Enums -----------------------------------------------------------------
+
+// Declared in severity order: PostgreSQL sorts enum values by declaration
+// order, so `sort=requestedPriority` is only meaningful with this ordering.
+enum Priority {
+  LOW
+  MEDIUM
+  HIGH
+  URGENT
+}
+
+enum TicketStatus {
+  NEW
+}
+
+enum Role {
+  REQUESTER
+  STAFF
+  ADMIN
+}
+
+// --- Reference data --------------------------------------------------------
+
 model Category {
   id        Int      @id @default(autoincrement())
   name      String   @unique
+  active    Boolean  @default(true)
   createdAt DateTime @default(now())
+
+  tickets Ticket[]
 }
-// ---------------------------------------------------------------------------
+
+model RelatedSystem {
+  id        Int      @id @default(autoincrement())
+  name      String   @unique
+  active    Boolean  @default(true)
+  createdAt DateTime @default(now())
+
+  tickets Ticket[]
+}
+
+// --- Identity --------------------------------------------------------------
+
+// The Lab 2 "Development Requester". This is a testing mechanism, not
+// authentication. `passwordHash` and `role` are unused in Lab 2 and exist so
+// that Lab 3 adds authentication to this table instead of migrating to a new
+// identity table (BR-49).
+model RequesterUser {
+  id           Int      @id @default(autoincrement())
+  fullName     String
+  email        String   @unique
+  department   String?
+  active       Boolean  @default(true)
+  role         Role     @default(REQUESTER)
+  passwordHash String?
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  tickets            Ticket[]
+  uploadedAttachments Attachment[] @relation("AttachmentUploader")
+  removedAttachments  Attachment[] @relation("AttachmentRemover")
+
+  @@index([active])
+}
+
+// --- Tickets ---------------------------------------------------------------
+
+model Ticket {
+  id                Int          @id @default(autoincrement())
+  ticketNumber      String       @unique
+  requesterId       Int
+  categoryId        Int
+  relatedSystemId   Int
+  requestedPriority Priority
+  summary           String       @db.VarChar(200)
+  description       String       @db.Text
+  currentStatus     TicketStatus @default(NEW)
+  createdAt         DateTime     @default(now())
+  updatedAt         DateTime     @updatedAt
+
+  // Restrict, not Cascade: reference data must not be deletable while tickets
+  // point at it. Deactivate it instead.
+  requester     RequesterUser @relation(fields: [requesterId], references: [id], onDelete: Restrict)
+  category      Category      @relation(fields: [categoryId], references: [id], onDelete: Restrict)
+  relatedSystem RelatedSystem @relation(fields: [relatedSystemId], references: [id], onDelete: Restrict)
+  attachments   Attachment[]
+
+  @@index([requesterId, createdAt])
+  @@index([requesterId, categoryId])
+  @@index([requesterId, relatedSystemId])
+}
+
+// An Attachment is active if and only if `removedAt` is null. That single
+// nullable timestamp is the only source of truth — there is deliberately no
+// companion boolean, because two representations of one fact can disagree.
+model Attachment {
+  id                    Int       @id @default(autoincrement())
+  ticketId              Int
+  originalFilename      String
+  storedFilename        String    @unique
+  mimeType              String
+  sizeBytes             Int
+  uploadedByRequesterId Int
+  uploadedAt            DateTime  @default(now())
+  removedAt             DateTime?
+  removedByRequesterId  Int?
+  removalReason         String?
+
+  ticket     Ticket         @relation(fields: [ticketId], references: [id], onDelete: Cascade)
+  uploadedBy RequesterUser  @relation("AttachmentUploader", fields: [uploadedByRequesterId], references: [id], onDelete: Restrict)
+  removedBy  RequesterUser? @relation("AttachmentRemover", fields: [removedByRequesterId], references: [id], onDelete: Restrict)
+
+  @@index([ticketId, removedAt])
+}
+
+// --- Ticket number allocation ----------------------------------------------
+
+// One row per calendar year. Allocation runs inside the ticket-creation
+// transaction as `UPDATE ... SET lastValue = lastValue + 1 ... RETURNING`,
+// which row-locks the year so concurrent creates serialise on it. Gap-free and
+// race-free with no retry loop; see specification.md §7 for why this beats
+// MAX(ticketNumber)+1 and a per-year sequence.
+model TicketCounter {
+  year      Int @id
+  lastValue Int @default(0)
+}

--- a/server/prisma/seed.ts
+++ b/server/prisma/seed.ts
@@ -1,23 +1,95 @@
 import { getPrisma } from "../src/prisma.js";
 
-// Issue 3 — seed the four supported categories.
-// The four names are: Account and Access, Hardware, Software, Network.
-// Requirement: running the seed twice must NOT create duplicates.
-// Hint: prisma.category.upsert({ where:{name}, update:{}, create:{name} }).
+// Every row is upserted on its natural key with an empty `update`, so running
+// the seed repeatedly never duplicates or mutates existing data (BR-09).
+
+const CATEGORIES = ["Account and Access", "Hardware", "Software", "Network"];
+
+const RELATED_SYSTEMS = [
+  "Email",
+  "Campus Wi-Fi",
+  "VPN",
+  "LEB2 App",
+  "Grade Submission App",
+  "Printer",
+  "Corporate Laptop",
+];
+
+const REQUESTERS = [
+  {
+    fullName: "Jennifer Anderson",
+    email: "jennifer.anderson@kmutt.ac.th",
+    department: "Faculty of Engineering",
+    active: true,
+  },
+  {
+    fullName: "Michael Brown",
+    email: "michael.brown@kmutt.ac.th",
+    department: "Office of the Registrar",
+    active: true,
+  },
+  {
+    fullName: "Sarah Johnson",
+    email: "sarah.johnson@kmutt.ac.th",
+    department: "Faculty of Science",
+    active: true,
+  },
+  {
+    fullName: "David Lee",
+    email: "david.lee@kmutt.ac.th",
+    department: "Library",
+    active: true,
+  },
+  // Must not appear in the Development Requester selector (BR-06). Its absence
+  // is asserted by AC-01.
+  {
+    fullName: "Somsri Inactive",
+    email: "somsri.inactive@kmutt.ac.th",
+    department: "Alumni Relations",
+    active: false,
+  },
+];
+
 async function main() {
   const prisma = getPrisma();
-  void prisma;
-  const categories = ["Account and Access", "Hardware", "Software", "Network"];
 
-  for (const name of categories) {
+  for (const name of CATEGORIES) {
     await prisma.category.upsert({
       where: { name },
       update: {},
       create: { name },
     });
   }
-  
-  console.log("Seeded categories successfully.");
+
+  for (const name of RELATED_SYSTEMS) {
+    await prisma.relatedSystem.upsert({
+      where: { name },
+      update: {},
+      create: { name },
+    });
+  }
+
+  for (const requester of REQUESTERS) {
+    await prisma.requesterUser.upsert({
+      where: { email: requester.email },
+      update: {},
+      create: requester,
+    });
+  }
+
+  // Bootstrap this year's ticket counter so the first ticket creation does not
+  // race on inserting it.
+  await prisma.ticketCounter.upsert({
+    where: { year: new Date().getFullYear() },
+    update: {},
+    create: { year: new Date().getFullYear() },
+  });
+
+  const activeRequesters = REQUESTERS.filter((r) => r.active).length;
+  console.log(
+    `Seeded ${CATEGORIES.length} categories, ${RELATED_SYSTEMS.length} related systems, ` +
+      `${activeRequesters} active and ${REQUESTERS.length - activeRequesters} inactive development requesters.`
+  );
 }
 
 main()


### PR DESCRIPTION
Add the Ticket, Attachment, RelatedSystem, RequesterUser and TicketCounter models plus the Priority, TicketStatus and Role enums, and extend Category with an active flag.

Split into two migrations so no intermediate state is invalid: the Category column is added with a default first, which keeps the already-seeded rows and the Lab 1 categories test intact, before the core models land.

An attachment is active if and only if removedAt is null, so soft removal has a single source of truth. TicketCounter backs gap-free per-year ticket number allocation under concurrency without a retry loop.

Extend the seed with related systems and development requesters, including one inactive requester whose absence from the selector is an acceptance criterion. Every row is still upserted on its natural key, so repeated runs do not duplicate.