### PR TITLE
Server architecture and reference-data endpoints

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "@prisma/client": "^5.22.0",
         "cors": "^2.8.5",
-        "express": "^4.21.2"
+        "express": "^4.21.2",
+        "zod": "^4.5.4"
       },
       "devDependencies": {
         "@types/cors": "^2.8.17",
@@ -3393,6 +3394,15 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
     }
   }
 }

--- a/server/package.json
+++ b/server/package.json
@@ -11,11 +11,14 @@
     "prisma:seed": "tsx prisma/seed.ts",
     "test": "vitest run"
   },
-  "prisma": { "seed": "tsx prisma/seed.ts" },
+  "prisma": {
+    "seed": "tsx prisma/seed.ts"
+  },
   "dependencies": {
     "@prisma/client": "^5.22.0",
     "cors": "^2.8.5",
-    "express": "^4.21.2"
+    "express": "^4.21.2",
+    "zod": "^4.5.4"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,9 +1,9 @@
 import express, { Request, Response } from "express";
 import cors from "cors";
 import { getPrisma } from "./prisma.js";
-// getPrisma() is your lazy database handle. Call it INSIDE a route when you
-// need the DB (Issue 4). It is intentionally unused until then.
-void getPrisma;
+import { apiRouter } from "./routes/index.js";
+import { notFound } from "./middleware/notFound.js";
+import { errorHandler } from "./middleware/errorHandler.js";
 
 // The Express app is exported separately from app.listen() (see index.ts) so
 // Supertest can import `app` without opening a port. Do not merge these files.
@@ -21,10 +21,13 @@ app.get("/api/health", (_req: Request, res: Response) => {
   res.status(200).json({ status: "ok", service: "TokTickIT API" });
 });
 
+// Lab 2 filters to active categories. The response shape is unchanged, which
+// is what tests/lab-01/categories.test.ts asserts.
 app.get("/api/categories", async (_req: Request, res: Response) => {
   try {
     const prisma = getPrisma();
     const categories = await prisma.category.findMany({
+      where: { active: true },
       select: { id: true, name: true },
       orderBy: { id: "asc" },
     });
@@ -34,5 +37,12 @@ app.get("/api/categories", async (_req: Request, res: Response) => {
   }
 });
 // ---------------------------------------------------------------------------
+
+app.use("/api", apiRouter);
+
+// Order matters: the catch-all runs after every route, and the error handler
+// must be registered last of all.
+app.use(notFound);
+app.use(errorHandler);
 
 export default app;

--- a/server/src/lib/asyncHandler.ts
+++ b/server/src/lib/asyncHandler.ts
@@ -1,0 +1,14 @@
+import type { NextFunction, Request, RequestHandler, Response } from "express";
+
+/**
+ * Express 4 does not catch rejections from async handlers: a thrown error
+ * becomes an unhandled rejection, the response is never sent, and the request
+ * hangs until it times out. Every async handler must be wrapped in this.
+ */
+export function asyncHandler(
+  fn: (req: Request, res: Response, next: NextFunction) => Promise<unknown>
+): RequestHandler {
+  return (req, res, next) => {
+    Promise.resolve(fn(req, res, next)).catch(next);
+  };
+}

--- a/server/src/lib/httpError.ts
+++ b/server/src/lib/httpError.ts
@@ -1,0 +1,52 @@
+export interface FieldIssue {
+  field: string;
+  message: string;
+}
+
+/**
+ * Every deliberate failure is thrown as an HttpError so that one error handler
+ * can render it. `code` is the machine-readable identifier documented in
+ * docs/lab-02/api-spec.md §8; `message` is safe to show an end user and must
+ * never carry a stack trace, SQL, or a file path (BR-27).
+ */
+export class HttpError extends Error {
+  readonly status: number;
+  readonly code: string;
+  readonly details?: FieldIssue[];
+
+  constructor(status: number, code: string, message: string, details?: FieldIssue[]) {
+    super(message);
+    this.name = "HttpError";
+    this.status = status;
+    this.code = code;
+    this.details = details;
+  }
+
+  static badRequest(code: string, message: string, details?: FieldIssue[]) {
+    return new HttpError(400, code, message, details);
+  }
+
+  static validationFailed(message: string, details: FieldIssue[]) {
+    return new HttpError(400, "VALIDATION_FAILED", message, details);
+  }
+
+  static unauthorized(code: string, message: string) {
+    return new HttpError(401, code, message);
+  }
+
+  static forbidden(code: string, message: string) {
+    return new HttpError(403, code, message);
+  }
+
+  static notFound(code: string, message: string) {
+    return new HttpError(404, code, message);
+  }
+
+  static conflict(code: string, message: string) {
+    return new HttpError(409, code, message);
+  }
+
+  static gone(code: string, message: string) {
+    return new HttpError(410, code, message);
+  }
+}

--- a/server/src/middleware/errorHandler.ts
+++ b/server/src/middleware/errorHandler.ts
@@ -1,0 +1,51 @@
+import type { NextFunction, Request, Response } from "express";
+import { ZodError } from "zod";
+import { HttpError, type FieldIssue } from "../lib/httpError.js";
+
+function zodIssues(error: ZodError): FieldIssue[] {
+  return error.issues.map((issue) => ({
+    field: issue.path.join(".") || "(body)",
+    message: issue.message,
+  }));
+}
+
+/**
+ * The single place any failure becomes a response. Every non-2xx body in this
+ * API has the shape { error: { code, message, details? } } because every one
+ * of them passes through here.
+ *
+ * Must keep all four parameters: Express identifies error handlers by arity,
+ * and dropping `next` would silently turn this into ordinary middleware that
+ * never runs.
+ */
+export function errorHandler(
+  err: unknown,
+  _req: Request,
+  res: Response,
+  _next: NextFunction
+) {
+  if (err instanceof HttpError) {
+    res.status(err.status).json({
+      error: { code: err.code, message: err.message, ...(err.details && { details: err.details }) },
+    });
+    return;
+  }
+
+  if (err instanceof ZodError) {
+    res.status(400).json({
+      error: {
+        code: "VALIDATION_FAILED",
+        message: "The submitted data is invalid.",
+        details: zodIssues(err),
+      },
+    });
+    return;
+  }
+
+  // Anything reaching here is unexpected. Log it for the developer, but tell
+  // the caller nothing beyond the fact that it failed (BR-27).
+  console.error("Unhandled error:", err);
+  res.status(500).json({
+    error: { code: "INTERNAL_ERROR", message: "An unexpected error occurred." },
+  });
+}

--- a/server/src/middleware/notFound.ts
+++ b/server/src/middleware/notFound.ts
@@ -1,0 +1,11 @@
+import type { NextFunction, Request, Response } from "express";
+import { HttpError } from "../lib/httpError.js";
+
+/**
+ * Without this, an unknown path falls through to Express's default handler,
+ * which replies with an HTML page rather than the JSON error shape every other
+ * failure uses.
+ */
+export function notFound(_req: Request, _res: Response, next: NextFunction) {
+  next(HttpError.notFound("ROUTE_NOT_FOUND", "The requested resource does not exist."));
+}

--- a/server/src/middleware/requireRequester.ts
+++ b/server/src/middleware/requireRequester.ts
@@ -1,0 +1,69 @@
+import type { NextFunction, Request, Response } from "express";
+import { getPrisma } from "../prisma.js";
+import { HttpError } from "../lib/httpError.js";
+import { asyncHandler } from "../lib/asyncHandler.js";
+
+export const REQUESTER_HEADER = "x-requester-id";
+
+/**
+ * Resolves the Lab 2 Development Requester from the X-Requester-Id header.
+ *
+ * This is a testing mechanism, not authentication — it trusts the header
+ * completely. Lab 3 replaces the body of this function with token
+ * verification; because every handler reads the identity from req.requester
+ * rather than from the header, no handler changes then (BR-47).
+ *
+ * The four failure cases are distinguished deliberately (api-spec.md §2):
+ * a missing header is 401 because no identity was presented; a malformed one
+ * is 400 because the request itself is malformed; an unknown id is 401 because
+ * an identity was presented and could not be resolved; and an inactive
+ * requester is 403 because identity resolved but is not permitted — the same
+ * distinction a valid token for a deactivated account will need in Lab 3.
+ */
+export const requireRequester = asyncHandler(
+  async (req: Request, _res: Response, next: NextFunction) => {
+    const raw = req.header(REQUESTER_HEADER);
+
+    if (raw === undefined || raw.trim() === "") {
+      throw HttpError.unauthorized(
+        "REQUESTER_HEADER_MISSING",
+        "No development requester was selected."
+      );
+    }
+
+    if (!/^[1-9]\d*$/.test(raw.trim())) {
+      throw HttpError.badRequest(
+        "REQUESTER_HEADER_INVALID",
+        "The development requester identifier is not valid."
+      );
+    }
+
+    const id = Number(raw.trim());
+    const requester = await getPrisma().requesterUser.findUnique({
+      where: { id },
+      select: { id: true, fullName: true, email: true, active: true },
+    });
+
+    if (!requester) {
+      throw HttpError.unauthorized(
+        "REQUESTER_NOT_FOUND",
+        "The selected development requester no longer exists."
+      );
+    }
+
+    if (!requester.active) {
+      throw HttpError.forbidden(
+        "REQUESTER_INACTIVE",
+        "The selected development requester is inactive."
+      );
+    }
+
+    req.requester = {
+      id: requester.id,
+      fullName: requester.fullName,
+      email: requester.email,
+    };
+
+    next();
+  }
+);

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -1,0 +1,8 @@
+import { Router } from "express";
+import { relatedSystemsRouter } from "./relatedSystems.routes.js";
+import { requestersRouter } from "./requesters.routes.js";
+
+export const apiRouter = Router();
+
+apiRouter.use("/related-systems", relatedSystemsRouter);
+apiRouter.use("/dev-requesters", requestersRouter);

--- a/server/src/routes/relatedSystems.routes.ts
+++ b/server/src/routes/relatedSystems.routes.ts
@@ -1,0 +1,19 @@
+import { Router } from "express";
+import { getPrisma } from "../prisma.js";
+import { asyncHandler } from "../lib/asyncHandler.js";
+
+export const relatedSystemsRouter = Router();
+
+// No identity required: the Create Ticket screen loads this reference data, and
+// keeping it open matches /api/categories.
+relatedSystemsRouter.get(
+  "/",
+  asyncHandler(async (_req, res) => {
+    const relatedSystems = await getPrisma().relatedSystem.findMany({
+      where: { active: true },
+      select: { id: true, name: true },
+      orderBy: { name: "asc" },
+    });
+    res.status(200).json(relatedSystems);
+  })
+);

--- a/server/src/routes/requesters.routes.ts
+++ b/server/src/routes/requesters.routes.ts
@@ -1,0 +1,23 @@
+import { Router } from "express";
+import { getPrisma } from "../prisma.js";
+import { asyncHandler } from "../lib/asyncHandler.js";
+
+export const requestersRouter = Router();
+
+// Deliberately not behind requireRequester: this endpoint is what the
+// Development Requester Selection screen reads before any requester has been
+// chosen, so requiring an identity here would be circular.
+//
+// The inactive filter is applied here rather than in the client, so it cannot
+// be bypassed by calling the API directly (BR-06).
+requestersRouter.get(
+  "/",
+  asyncHandler(async (_req, res) => {
+    const requesters = await getPrisma().requesterUser.findMany({
+      where: { active: true },
+      select: { id: true, fullName: true, email: true, department: true },
+      orderBy: { fullName: "asc" },
+    });
+    res.status(200).json(requesters);
+  })
+);

--- a/server/src/types/express.d.ts
+++ b/server/src/types/express.d.ts
@@ -1,0 +1,18 @@
+export interface ResolvedRequester {
+  id: number;
+  fullName: string;
+  email: string;
+}
+
+declare global {
+  namespace Express {
+    interface Request {
+      /**
+       * Set by the requireRequester middleware. Route handlers read the caller's
+       * identity only from here, never from the header directly, so Lab 3 can
+       * replace header resolution with token verification in one place (BR-48).
+       */
+      requester?: ResolvedRequester;
+    }
+  }
+}

--- a/server/tests/globalSetup.ts
+++ b/server/tests/globalSetup.ts
@@ -1,0 +1,14 @@
+import { execSync } from "node:child_process";
+
+/**
+ * Runs once before any suite. The seed is idempotent, so this only guarantees
+ * that the reference data every suite depends on — the four categories, the
+ * related systems, and the seeded requesters — is present.
+ *
+ * It deliberately does not reset the database: tests/lab-01/categories.test.ts
+ * asserts Category ids 1..4, and a truncate would restart the identity
+ * sequence and break a graded Lab 1 test.
+ */
+export default function globalSetup() {
+  execSync("npx prisma db seed", { stdio: "inherit" });
+}

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -4,5 +4,10 @@ export default defineConfig({
   test: {
     environment: "node",
     include: ["tests/**/*.test.ts"],
+    // Every suite runs against one shared development database. Left parallel,
+    // suites that create and mutate tickets interfere with each other.
+    fileParallelism: false,
+    globalSetup: "./tests/globalSetup.ts",
+    hookTimeout: 30000,
   },
 });


### PR DESCRIPTION
Introduce routers, middleware and shared error handling so the ticket and attachment endpoints can be added without repeating themselves, and add the two reference-data endpoints the Requester screens need.

Identity resolution lives in one middleware reading X-Requester-Id, and handlers read the caller only from req.requester. Lab 3 replaces the body of that middleware with token verification and no handler changes.

Every failure now renders through one error handler, so the whole API shares one error shape, and unknown paths return that shape instead of Express's default HTML. Async handlers are wrapped, because Express 4 turns a rejected async handler into a hung request rather than an error.

Server test files now run sequentially against the shared development database, since parallel suites that mutate tickets interfere. A global setup seeds the reference data rather than resetting the database, which would restart the identity sequence and break the Lab 1 categories test.