### PR TITLE
Create Ticket API with race-free ticket number allocation

### DIFF
--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -35,10 +35,10 @@ Status column: `Planned` until implemented, then `Pass`.
 
 | Test ID | Type | Requirement / AC | What it tests | Expected result | Automated test file | Final |
 |---|---|---|---|---|---|---|
-| UNIT-01 | Unit | BR-01, AC-09 | Ticket number formatter | `format(2026, 42)` returns `TKT-2026-000042` | `server/tests/lab-02/create-ticket.api.test.ts` | Planned |
+| UNIT-01 | Unit | BR-01, AC-09 | Ticket number formatter | `format(2026, 42)` returns `TKT-2026-000042` | `server/tests/lab-02/create-ticket.api.test.ts` | Pass |
 | UNIT-02 | Unit | BR-19, BR-20 | Ticket list query schema | `pageSize=7` and `page=0` are rejected; defaults applied when absent | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
 | UNIT-03 | Unit | BR-29 | Attachment type check | Permitted extension + MIME accepted; either one wrong rejected | `server/tests/lab-02/attachments.api.test.ts` | Planned |
-| UNIT-04 | Unit | BR-21, BR-22 | Trimming before validation | `"  hi  "` fails the 5-character minimum after trimming | `server/tests/lab-02/create-ticket.api.test.ts` | Planned |
+| UNIT-04 | Unit | BR-21, BR-22 | Trimming before validation | `"  hi  "` fails the 5-character minimum after trimming | `server/tests/lab-02/create-ticket.api.test.ts` | Pass |
 
 ### 2.2 API — create ticket
 
@@ -46,21 +46,21 @@ File: `server/tests/lab-02/create-ticket.api.test.ts`
 
 | Test ID | Type | Requirement / AC | What it tests | Expected result | Final |
 |---|---|---|---|---|---|
-| API-01 | API | AC-07 | Create with valid data | 201; one ticket saved; ticket number returned | Planned |
-| API-02 | API | AC-08 | Defaults and ownership on create | `currentStatus = NEW`; `requesterId` matches the header | Planned |
-| API-03 | API | AC-09 | Ticket number format | Matches `/^TKT-\d{4}-\d{6}$/` with the current year | Planned |
-| API-04 | API | AC-10, BR-05 | Concurrent creation | 8 parallel creates return 8 distinct ticket numbers | Planned |
-| API-05 | API | AC-12, BR-21 | Summary too short | 400 `VALIDATION_FAILED`; `details` names `summary` | Planned |
-| API-06 | API | BR-22 | Description too short | 400; `details` names `description` | Planned |
-| API-07 | API | BR-21 | Summary over 200 characters | 400; `details` names `summary` | Planned |
-| API-08 | API | BR-23 | Missing required fields | 400; every missing field appears in `details` | Planned |
-| API-09 | API | BR-23 | Invalid priority value | 400; `details` names `requestedPriority` | Planned |
-| API-10 | API | AC-16, D-09 | Inactive or unknown `categoryId` | 400, **not** 404; `details` names `categoryId` | Planned |
-| API-11 | API | BR-04 | Client-supplied `ticketNumber` and `currentStatus` | Ignored; server values used instead | Planned |
-| API-12 | API | AC-43 | Missing identity header | 401 `REQUESTER_HEADER_MISSING` | Planned |
-| API-13 | API | §2 | Non-numeric identity header | 400 `REQUESTER_HEADER_INVALID` | Planned |
-| API-14 | API | §2 | Unknown requester id | 401 `REQUESTER_NOT_FOUND` | Planned |
-| API-15 | API | AC-44, BR-06 | Inactive requester id | 403 `REQUESTER_INACTIVE` | Planned |
+| API-01 | API | AC-07 | Create with valid data | 201; one ticket saved; ticket number returned | Pass |
+| API-02 | API | AC-08 | Defaults and ownership on create | `currentStatus = NEW`; `requesterId` matches the header | Pass |
+| API-03 | API | AC-09 | Ticket number format | Matches `/^TKT-\d{4}-\d{6}$/` with the current year | Pass |
+| API-04 | API | AC-10, BR-05 | Concurrent creation | 8 parallel creates return 8 distinct ticket numbers | Pass |
+| API-05 | API | AC-12, BR-21 | Summary too short | 400 `VALIDATION_FAILED`; `details` names `summary` | Pass |
+| API-06 | API | BR-22 | Description too short | 400; `details` names `description` | Pass |
+| API-07 | API | BR-21 | Summary over 200 characters | 400; `details` names `summary` | Pass |
+| API-08 | API | BR-23 | Missing required fields | 400; every missing field appears in `details` | Pass |
+| API-09 | API | BR-23 | Invalid priority value | 400; `details` names `requestedPriority` | Pass |
+| API-10 | API | AC-16, D-09 | Inactive or unknown `categoryId` | 400, **not** 404; `details` names `categoryId` | Pass |
+| API-11 | API | BR-04 | Client-supplied `ticketNumber` and `currentStatus` | Ignored; server values used instead | Pass |
+| API-12 | API | AC-43 | Missing identity header | 401 `REQUESTER_HEADER_MISSING` | Pass |
+| API-13 | API | §2 | Non-numeric identity header | 400 `REQUESTER_HEADER_INVALID` | Pass |
+| API-14 | API | §2 | Unknown requester id | 401 `REQUESTER_NOT_FOUND` | Pass |
+| API-15 | API | AC-44, BR-06 | Inactive requester id | 403 `REQUESTER_INACTIVE` | Pass |
 
 ### 2.3 API — my tickets
 

--- a/server/src/lib/validation.ts
+++ b/server/src/lib/validation.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+
+const positiveInt = (label: string) =>
+  z.number({ error: `${label} is required.` }).int(`${label} must be a whole number.`).positive(`${label} is required.`);
+
+/**
+ * Bounds are justified in specification.md D-08: the lower bounds reject
+ * placeholder input such as "help", 200 keeps a summary readable in one list
+ * column, and 5000 accommodates a pasted log excerpt without unbounded payloads.
+ *
+ * Trimming happens before length checks, so "     " fails the minimum rather
+ * than passing as five characters (BR-21).
+ *
+ * ticketNumber, currentStatus and requesterId are deliberately absent: they are
+ * system-generated, and unknown keys are stripped rather than rejected, so a
+ * client that sends them is ignored rather than errored (BR-04).
+ */
+export const createTicketSchema = z.object({
+  categoryId: positiveInt("Category"),
+  relatedSystemId: positiveInt("Related System"),
+  requestedPriority: z.enum(["LOW", "MEDIUM", "HIGH", "URGENT"], {
+    error: "Requested Priority must be one of LOW, MEDIUM, HIGH or URGENT.",
+  }),
+  summary: z
+    .string({ error: "Summary is required." })
+    .trim()
+    .min(5, "Summary must be at least 5 characters.")
+    .max(200, "Summary must be at most 200 characters."),
+  description: z
+    .string({ error: "Description is required." })
+    .trim()
+    .min(10, "Description must be at least 10 characters.")
+    .max(5000, "Description must be at most 5000 characters."),
+});
+
+export type CreateTicketInput = z.infer<typeof createTicketSchema>;
+
+/** Path parameters arrive as strings; this both validates and converts. */
+export const idParamSchema = z.object({
+  id: z
+    .string()
+    .regex(/^[1-9]\d*$/, "The identifier must be a positive whole number.")
+    .transform(Number),
+});

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -1,8 +1,10 @@
 import { Router } from "express";
 import { relatedSystemsRouter } from "./relatedSystems.routes.js";
 import { requestersRouter } from "./requesters.routes.js";
+import { ticketsRouter } from "./tickets.routes.js";
 
 export const apiRouter = Router();
 
 apiRouter.use("/related-systems", relatedSystemsRouter);
 apiRouter.use("/dev-requesters", requestersRouter);
+apiRouter.use("/tickets", ticketsRouter);

--- a/server/src/routes/tickets.routes.ts
+++ b/server/src/routes/tickets.routes.ts
@@ -1,0 +1,20 @@
+import { Router } from "express";
+import { asyncHandler } from "../lib/asyncHandler.js";
+import { createTicketSchema } from "../lib/validation.js";
+import { requireRequester } from "../middleware/requireRequester.js";
+import { createTicket } from "../services/tickets.service.js";
+
+export const ticketsRouter = Router();
+
+// Ownership starts here: every route below resolves the caller once, and no
+// handler reads the identity from anywhere else (BR-48).
+ticketsRouter.use(requireRequester);
+
+ticketsRouter.post(
+  "/",
+  asyncHandler(async (req, res) => {
+    const input = createTicketSchema.parse(req.body);
+    const ticket = await createTicket(req.requester!.id, input);
+    res.status(201).json(ticket);
+  })
+);

--- a/server/src/services/ticketNumber.service.ts
+++ b/server/src/services/ticketNumber.service.ts
@@ -1,0 +1,42 @@
+import type { Prisma } from "@prisma/client";
+
+export const TICKET_NUMBER_PATTERN = /^TKT-\d{4}-\d{6}$/;
+
+export function formatTicketNumber(year: number, sequence: number): string {
+  return `TKT-${year}-${String(sequence).padStart(6, "0")}`;
+}
+
+/**
+ * Allocates the next ticket number for `year`, and must be called inside the
+ * same transaction that inserts the ticket.
+ *
+ * The UPDATE ... RETURNING takes a row lock on that year's counter for the rest
+ * of the transaction, so concurrent creates serialise on it and each receives a
+ * distinct value. That is why this needs no retry loop.
+ *
+ * MAX(ticketNumber)+1 was rejected because two concurrent readers can observe
+ * the same maximum — a real race that passes tests only by luck. A PostgreSQL
+ * sequence was rejected because it cannot restart per calendar year without a
+ * scheduled job or a sequence per year. See specification.md §7.
+ */
+export async function allocateTicketNumber(
+  tx: Prisma.TransactionClient,
+  year: number
+): Promise<string> {
+  // The counter row is seeded for the current year, but a ticket created in a
+  // year that has not been seeded must still work.
+  await tx.$executeRaw`
+    INSERT INTO "TicketCounter" ("year", "lastValue")
+    VALUES (${year}, 0)
+    ON CONFLICT ("year") DO NOTHING
+  `;
+
+  const rows = await tx.$queryRaw<{ lastValue: number }[]>`
+    UPDATE "TicketCounter"
+    SET "lastValue" = "lastValue" + 1
+    WHERE "year" = ${year}
+    RETURNING "lastValue"
+  `;
+
+  return formatTicketNumber(year, rows[0].lastValue);
+}

--- a/server/src/services/tickets.service.ts
+++ b/server/src/services/tickets.service.ts
@@ -1,0 +1,101 @@
+import type { Prisma } from "@prisma/client";
+import { getPrisma } from "../prisma.js";
+import { HttpError, type FieldIssue } from "../lib/httpError.js";
+import { allocateTicketNumber } from "./ticketNumber.service.js";
+import type { CreateTicketInput } from "../lib/validation.js";
+
+/** The relations every ticket-detail response includes. */
+const detailInclude = {
+  category: { select: { id: true, name: true } },
+  relatedSystem: { select: { id: true, name: true } },
+  requester: { select: { id: true, fullName: true, email: true, department: true } },
+  attachments: { orderBy: { uploadedAt: "asc" } },
+} satisfies Prisma.TicketInclude;
+
+type TicketWithDetail = Prisma.TicketGetPayload<{ include: typeof detailInclude }>;
+
+export function serializeAttachment(attachment: TicketWithDetail["attachments"][number]) {
+  return {
+    id: attachment.id,
+    originalFilename: attachment.originalFilename,
+    mimeType: attachment.mimeType,
+    sizeBytes: attachment.sizeBytes,
+    uploadedAt: attachment.uploadedAt,
+    isRemoved: attachment.removedAt !== null,
+    removedAt: attachment.removedAt,
+    removalReason: attachment.removalReason,
+  };
+}
+
+export function serializeTicketDetail(ticket: TicketWithDetail) {
+  return {
+    id: ticket.id,
+    ticketNumber: ticket.ticketNumber,
+    summary: ticket.summary,
+    description: ticket.description,
+    requestedPriority: ticket.requestedPriority,
+    currentStatus: ticket.currentStatus,
+    createdAt: ticket.createdAt,
+    updatedAt: ticket.updatedAt,
+    category: ticket.category,
+    relatedSystem: ticket.relatedSystem,
+    requester: ticket.requester,
+    attachments: ticket.attachments.map(serializeAttachment),
+  };
+}
+
+/**
+ * An unknown or inactive reference id is a field-level validation failure, not
+ * a missing resource: the fault is in a value the form submitted, so it belongs
+ * with the other messages the form renders below its fields (BR-23, D-09).
+ */
+async function assertReferenceDataIsUsable(input: CreateTicketInput): Promise<void> {
+  const prisma = getPrisma();
+  const [category, relatedSystem] = await Promise.all([
+    prisma.category.findFirst({ where: { id: input.categoryId, active: true }, select: { id: true } }),
+    prisma.relatedSystem.findFirst({
+      where: { id: input.relatedSystemId, active: true },
+      select: { id: true },
+    }),
+  ]);
+
+  const details: FieldIssue[] = [];
+  if (!category) {
+    details.push({ field: "categoryId", message: "Select a valid category." });
+  }
+  if (!relatedSystem) {
+    details.push({ field: "relatedSystemId", message: "Select a valid related system." });
+  }
+
+  if (details.length > 0) {
+    throw HttpError.validationFailed("The submitted data is invalid.", details);
+  }
+}
+
+export async function createTicket(requesterId: number, input: CreateTicketInput) {
+  await assertReferenceDataIsUsable(input);
+
+  const prisma = getPrisma();
+
+  // Allocation and insert share one transaction so the counter is never
+  // advanced for a ticket that fails to save.
+  const created = await prisma.$transaction(async (tx) => {
+    const ticketNumber = await allocateTicketNumber(tx, new Date().getFullYear());
+
+    return tx.ticket.create({
+      data: {
+        ticketNumber,
+        requesterId,
+        categoryId: input.categoryId,
+        relatedSystemId: input.relatedSystemId,
+        requestedPriority: input.requestedPriority,
+        summary: input.summary,
+        description: input.description,
+        // currentStatus defaults to NEW in the schema (BR-02).
+      },
+      include: detailInclude,
+    });
+  });
+
+  return serializeTicketDetail(created);
+}

--- a/server/tests/lab-02/create-ticket.api.test.ts
+++ b/server/tests/lab-02/create-ticket.api.test.ts
@@ -1,0 +1,263 @@
+import { randomUUID } from "node:crypto";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import request from "supertest";
+import { app } from "../../src/app.js";
+import { getPrisma } from "../../src/prisma.js";
+import {
+  formatTicketNumber,
+  TICKET_NUMBER_PATTERN,
+} from "../../src/services/ticketNumber.service.js";
+
+const prisma = getPrisma();
+
+// This suite creates its own requesters rather than using seeded ids, so it can
+// delete exactly what it made and assert only about its own data. Suites share
+// one development database (vitest.config.ts sets fileParallelism: false).
+let activeRequesterId: number;
+let inactiveRequesterId: number;
+let categoryId: number;
+let relatedSystemId: number;
+let inactiveCategoryId: number;
+
+const suiteTag = randomUUID();
+
+function validBody() {
+  return {
+    categoryId,
+    relatedSystemId,
+    requestedPriority: "MEDIUM",
+    summary: "Laptop battery drains quickly",
+    description: "The battery drains much faster than usual even when the system is idle.",
+  };
+}
+
+function post(body: object, requesterId: number | null = activeRequesterId) {
+  const req = request(app).post("/api/tickets").send(body);
+  return requesterId === null ? req : req.set("X-Requester-Id", String(requesterId));
+}
+
+/** Field names carried in a 400 VALIDATION_FAILED body. */
+function invalidFields(body: any): string[] {
+  return (body?.error?.details ?? []).map((d: { field: string }) => d.field);
+}
+
+beforeAll(async () => {
+  const active = await prisma.requesterUser.create({
+    data: { fullName: "Create Suite Active", email: `create-active-${suiteTag}@lab2.local`, active: true },
+  });
+  const inactive = await prisma.requesterUser.create({
+    data: { fullName: "Create Suite Inactive", email: `create-inactive-${suiteTag}@lab2.local`, active: false },
+  });
+  activeRequesterId = active.id;
+  inactiveRequesterId = inactive.id;
+
+  const category = await prisma.category.findFirstOrThrow({ where: { active: true } });
+  const relatedSystem = await prisma.relatedSystem.findFirstOrThrow({ where: { active: true } });
+  categoryId = category.id;
+  relatedSystemId = relatedSystem.id;
+
+  // The seed has no inactive category, so API-10 makes its own. It is filtered
+  // out of GET /api/categories, so the Lab 1 test that asserts the four active
+  // categories is unaffected.
+  const inactiveCategory = await prisma.category.create({
+    data: { name: `Retired Category ${suiteTag}`, active: false },
+  });
+  inactiveCategoryId = inactiveCategory.id;
+});
+
+afterAll(async () => {
+  // FK order: tickets before the requesters they point at.
+  await prisma.ticket.deleteMany({
+    where: { requesterId: { in: [activeRequesterId, inactiveRequesterId] } },
+  });
+  await prisma.requesterUser.deleteMany({
+    where: { id: { in: [activeRequesterId, inactiveRequesterId] } },
+  });
+  await prisma.category.deleteMany({ where: { id: inactiveCategoryId } });
+  await prisma.$disconnect();
+});
+
+describe("Ticket number formatting", () => {
+  it("UNIT-01: pads the sequence to six digits", () => {
+    expect(formatTicketNumber(2026, 42)).toBe("TKT-2026-000042");
+    expect(formatTicketNumber(2026, 1)).toBe("TKT-2026-000001");
+    expect(formatTicketNumber(2026, 123456)).toBe("TKT-2026-123456");
+  });
+});
+
+describe("POST /api/tickets — success", () => {
+  it("API-01: creates one ticket and returns its official number", async () => {
+    const res = await post(validBody());
+
+    expect(res.status).toBe(201);
+    expect(res.body.ticketNumber).toMatch(TICKET_NUMBER_PATTERN);
+    expect(res.body.summary).toBe("Laptop battery drains quickly");
+
+    const saved = await prisma.ticket.findUnique({ where: { id: res.body.id } });
+    expect(saved).not.toBeNull();
+    expect(saved!.ticketNumber).toBe(res.body.ticketNumber);
+  });
+
+  it("API-02: defaults the status to NEW and owns the ticket to the caller", async () => {
+    const res = await post(validBody());
+
+    expect(res.status).toBe(201);
+    expect(res.body.currentStatus).toBe("NEW");
+    expect(res.body.requester.id).toBe(activeRequesterId);
+
+    const saved = await prisma.ticket.findUniqueOrThrow({ where: { id: res.body.id } });
+    expect(saved.currentStatus).toBe("NEW");
+    expect(saved.requesterId).toBe(activeRequesterId);
+  });
+
+  it("API-03: numbers the ticket for the current year", async () => {
+    const res = await post(validBody());
+
+    expect(res.status).toBe(201);
+    expect(res.body.ticketNumber).toMatch(TICKET_NUMBER_PATTERN);
+    expect(res.body.ticketNumber.startsWith(`TKT-${new Date().getFullYear()}-`)).toBe(true);
+  });
+
+  it("API-11: ignores system-generated values supplied by the client", async () => {
+    const res = await post({
+      ...validBody(),
+      ticketNumber: "TKT-1999-000001",
+      currentStatus: "NEW",
+      requesterId: inactiveRequesterId,
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body.ticketNumber).not.toBe("TKT-1999-000001");
+    expect(res.body.requester.id).toBe(activeRequesterId);
+  });
+
+  it("API-04: allocates distinct numbers under concurrent creation", async () => {
+    const responses = await Promise.all(
+      Array.from({ length: 8 }, () => post(validBody()))
+    );
+
+    expect(responses.every((r) => r.status === 201)).toBe(true);
+
+    const numbers = responses.map((r) => r.body.ticketNumber);
+    expect(new Set(numbers).size).toBe(8);
+  });
+});
+
+describe("POST /api/tickets — validation", () => {
+  it("API-05: rejects a summary shorter than the minimum", async () => {
+    const res = await post({ ...validBody(), summary: "help" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_FAILED");
+    expect(invalidFields(res.body)).toContain("summary");
+  });
+
+  it("UNIT-04: trims before measuring length, so whitespace is not content", async () => {
+    const res = await post({ ...validBody(), summary: "        " });
+
+    expect(res.status).toBe(400);
+    expect(invalidFields(res.body)).toContain("summary");
+  });
+
+  it("API-06: rejects a description shorter than the minimum", async () => {
+    const res = await post({ ...validBody(), description: "too short" });
+
+    expect(res.status).toBe(400);
+    expect(invalidFields(res.body)).toContain("description");
+  });
+
+  it("API-07: rejects a summary longer than 200 characters", async () => {
+    const res = await post({ ...validBody(), summary: "x".repeat(201) });
+
+    expect(res.status).toBe(400);
+    expect(invalidFields(res.body)).toContain("summary");
+  });
+
+  it("API-08: names every missing required field", async () => {
+    const res = await post({});
+
+    expect(res.status).toBe(400);
+    expect(invalidFields(res.body)).toEqual(
+      expect.arrayContaining([
+        "categoryId",
+        "relatedSystemId",
+        "requestedPriority",
+        "summary",
+        "description",
+      ])
+    );
+  });
+
+  it("API-09: rejects a priority outside the permitted set", async () => {
+    const res = await post({ ...validBody(), requestedPriority: "CRITICAL" });
+
+    expect(res.status).toBe(400);
+    expect(invalidFields(res.body)).toContain("requestedPriority");
+  });
+
+  it("API-10: treats an unknown category as a field error, not a missing resource", async () => {
+    const res = await post({ ...validBody(), categoryId: 999_999 });
+
+    // 400 rather than 404: the fault is in a submitted field value, so it
+    // belongs with the other messages the form renders (BR-23, D-09).
+    expect(res.status).toBe(400);
+    expect(invalidFields(res.body)).toContain("categoryId");
+  });
+
+  it("API-10: treats an inactive category the same as an unknown one", async () => {
+    const res = await post({ ...validBody(), categoryId: inactiveCategoryId });
+
+    expect(res.status).toBe(400);
+    expect(invalidFields(res.body)).toContain("categoryId");
+  });
+
+  it("API-10: rejects an unknown related system", async () => {
+    const res = await post({ ...validBody(), relatedSystemId: 999_999 });
+
+    expect(res.status).toBe(400);
+    expect(invalidFields(res.body)).toContain("relatedSystemId");
+  });
+
+  it("saves nothing when validation fails", async () => {
+    const before = await prisma.ticket.count({ where: { requesterId: activeRequesterId } });
+    await post({ ...validBody(), summary: "no" });
+    const after = await prisma.ticket.count({ where: { requesterId: activeRequesterId } });
+
+    expect(after).toBe(before);
+  });
+});
+
+describe("POST /api/tickets — requester identity", () => {
+  it("API-12: rejects a request with no identity header", async () => {
+    const res = await post(validBody(), null);
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("REQUESTER_HEADER_MISSING");
+  });
+
+  it("API-13: rejects a malformed identity header", async () => {
+    const res = await request(app)
+      .post("/api/tickets")
+      .set("X-Requester-Id", "abc")
+      .send(validBody());
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("REQUESTER_HEADER_INVALID");
+  });
+
+  it("API-14: rejects an identity that cannot be resolved", async () => {
+    const res = await post(validBody(), 999_999);
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("REQUESTER_NOT_FOUND");
+  });
+
+  it("API-15: refuses an inactive requester", async () => {
+    const res = await post(validBody(), inactiveRequesterId);
+
+    // 403, not 401: the identity resolved but is not permitted. Lab 3 needs the
+    // same distinction for a valid token on a deactivated account.
+    expect(res.status).toBe(403);
+    expect(res.body.error.code).toBe("REQUESTER_INACTIVE");
+  });
+});


### PR DESCRIPTION
Add POST /api/tickets: zod validation, ownership taken from the resolved requester, and a full ticket detail response.

Ticket numbers come from a per-year counter incremented with UPDATE ... RETURNING inside the same transaction that inserts the ticket. That row lock makes concurrent creates serialise on it, so allocation is distinct and gap-free with no retry loop. MAX(ticketNumber)+1 would race, and a sequence cannot restart per year without extra machinery.

An unknown or inactive category is a 400 rather than a 404, because the fault is in a submitted field value and belongs with the other messages the form renders below its fields.

The suite creates its own requesters with randomised emails and deletes only what it made, so it can run against the shared development database without disturbing the seeded reference data the Lab 1 tests assert.