### PR TITLE
My Tickets list API with search, filters, sorting and pagina…

### DIFF
--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -36,7 +36,7 @@ Status column: `Planned` until implemented, then `Pass`.
 | Test ID | Type | Requirement / AC | What it tests | Expected result | Automated test file | Final |
 |---|---|---|---|---|---|---|
 | UNIT-01 | Unit | BR-01, AC-09 | Ticket number formatter | `format(2026, 42)` returns `TKT-2026-000042` | `server/tests/lab-02/create-ticket.api.test.ts` | Pass |
-| UNIT-02 | Unit | BR-19, BR-20 | Ticket list query schema | `pageSize=7` and `page=0` are rejected; defaults applied when absent | `server/tests/lab-02/my-tickets.api.test.ts` | Planned |
+| UNIT-02 | Unit | BR-19, BR-20 | Ticket list query schema | `pageSize=7` and `page=0` are rejected; defaults applied when absent | `server/tests/lab-02/my-tickets.api.test.ts` | Pass |
 | UNIT-03 | Unit | BR-29 | Attachment type check | Permitted extension + MIME accepted; either one wrong rejected | `server/tests/lab-02/attachments.api.test.ts` | Planned |
 | UNIT-04 | Unit | BR-21, BR-22 | Trimming before validation | `"  hi  "` fails the 5-character minimum after trimming | `server/tests/lab-02/create-ticket.api.test.ts` | Pass |
 
@@ -68,23 +68,23 @@ File: `server/tests/lab-02/my-tickets.api.test.ts`
 
 | Test ID | Type | Requirement / AC | What it tests | Expected result | Final |
 |---|---|---|---|---|---|
-| API-16 | API | AC-17, BR-11 | Ownership isolation | Requester B's list contains no ticket owned by A | Planned |
-| API-17 | API | BR-16 | `requesterId` query parameter ignored | Supplying it cannot widen the result set | Planned |
-| API-18 | API | AC-18, BR-14 | Search by ticket number | Case-insensitive substring match returns the ticket | Planned |
-| API-19 | API | AC-19, BR-14 | Search by summary | Case-insensitive substring match returns the tickets | Planned |
-| API-20 | API | AC-20 | Category filter | Every returned ticket has that Category | Planned |
-| API-21 | API | FR-13 | Related System filter | Every returned ticket has that Related System | Planned |
-| API-22 | API | FR-13 | Priority filter | Every returned ticket has that priority | Planned |
-| API-23 | API | BR-15 | Combined filters | Filters combine conjunctively | Planned |
-| API-24 | API | AC-21 | Sort by each whitelisted field, both orders | Ordering matches the request | Planned |
-| API-25 | API | BR-17 | Default sort | Newest first when no sort is supplied | Planned |
-| API-26 | API | AC-23, BR-18 | Stable pagination on tied sort values | Across consecutive pages no ticket repeats and none is skipped | Planned |
-| API-27 | API | AC-22 | Pagination boundaries | Page 2 is disjoint from page 1; last page is partial; `total` is the full count | Planned |
-| API-28 | API | AC-24, BR-19 | `pageSize=7` | 400, not a silently substituted size | Planned |
-| API-29 | API | BR-19 | `page=0` | 400 | Planned |
-| API-30 | API | BR-20 | `sort=password` | 400 — the whitelist rejects it | Planned |
-| API-31 | API | AC-25 | Requester with no tickets | 200 with `data: []`, `total: 0` | Planned |
-| API-32 | API | §5.2 | `attachmentCount` | Counts active attachments only; removed ones excluded | Planned |
+| API-16 | API | AC-17, BR-11 | Ownership isolation | Requester B's list contains no ticket owned by A | Pass |
+| API-17 | API | BR-16 | `requesterId` query parameter ignored | Supplying it cannot widen the result set | Pass |
+| API-18 | API | AC-18, BR-14 | Search by ticket number | Case-insensitive substring match returns the ticket | Pass |
+| API-19 | API | AC-19, BR-14 | Search by summary | Case-insensitive substring match returns the tickets | Pass |
+| API-20 | API | AC-20 | Category filter | Every returned ticket has that Category | Pass |
+| API-21 | API | FR-13 | Related System filter | Every returned ticket has that Related System | Pass |
+| API-22 | API | FR-13 | Priority filter | Every returned ticket has that priority | Pass |
+| API-23 | API | BR-15 | Combined filters | Filters combine conjunctively | Pass |
+| API-24 | API | AC-21 | Sort by each whitelisted field, both orders | Ordering matches the request | Pass |
+| API-25 | API | BR-17 | Default sort | Newest first when no sort is supplied | Pass |
+| API-26 | API | AC-23, BR-18 | Stable pagination on tied sort values | Across consecutive pages no ticket repeats and none is skipped | Pass |
+| API-27 | API | AC-22 | Pagination boundaries | Page 2 is disjoint from page 1; last page is partial; `total` is the full count | Pass |
+| API-28 | API | AC-24, BR-19 | `pageSize=7` | 400, not a silently substituted size | Pass |
+| API-29 | API | BR-19 | `page=0` | 400 | Pass |
+| API-30 | API | BR-20 | `sort=password` | 400 — the whitelist rejects it | Pass |
+| API-31 | API | AC-25 | Requester with no tickets | 200 with `data: []`, `total: 0` | Pass |
+| API-32 | API | §5.2 | `attachmentCount` | Counts active attachments only; removed ones excluded | Pass |
 
 ### 2.4 API — ticket detail
 

--- a/server/src/lib/validation.ts
+++ b/server/src/lib/validation.ts
@@ -42,3 +42,62 @@ export const idParamSchema = z.object({
     .regex(/^[1-9]\d*$/, "The identifier must be a positive whole number.")
     .transform(Number),
 });
+
+export const TICKET_SORT_FIELDS = [
+  "createdAt",
+  "ticketNumber",
+  "requestedPriority",
+  "summary",
+] as const;
+
+export const TICKET_PAGE_SIZES = [10, 20, 50] as const;
+
+/** An absent query parameter is the default; an empty string is treated as absent. */
+const optionalParam = <T extends z.ZodTypeAny>(schema: T) =>
+  z.preprocess((v) => (v === "" || v === undefined ? undefined : v), schema.optional());
+
+const numericParam = (label: string) =>
+  z
+    .string()
+    .regex(/^[1-9]\d*$/, `${label} must be a positive whole number.`)
+    .transform(Number);
+
+/**
+ * Invalid parameters are rejected rather than clamped. Silent correction cannot
+ * be asserted by a test, so `pageSize=7` is a 400 rather than quietly becoming
+ * 10 (BR-20).
+ *
+ * There is deliberately no `requesterId` parameter: ownership comes from the
+ * identity middleware alone, which is the whole point of enforcing it in the
+ * backend (BR-16).
+ */
+export const listTicketsQuerySchema = z.object({
+  page: optionalParam(numericParam("Page")).transform((v) => v ?? 1),
+  pageSize: optionalParam(
+    z
+      .string()
+      .transform(Number)
+      .refine(
+        (n) => (TICKET_PAGE_SIZES as readonly number[]).includes(n),
+        `Page size must be one of ${TICKET_PAGE_SIZES.join(", ")}.`
+      )
+  ).transform((v) => v ?? 10),
+  q: optionalParam(z.string().max(100, "Search text must be at most 100 characters.")),
+  categoryId: optionalParam(numericParam("Category")),
+  relatedSystemId: optionalParam(numericParam("Related System")),
+  priority: optionalParam(
+    z.enum(["LOW", "MEDIUM", "HIGH", "URGENT"], {
+      error: "Priority must be one of LOW, MEDIUM, HIGH or URGENT.",
+    })
+  ),
+  sort: optionalParam(
+    z.enum(TICKET_SORT_FIELDS, {
+      error: `Sort must be one of ${TICKET_SORT_FIELDS.join(", ")}.`,
+    })
+  ).transform((v) => v ?? "createdAt"),
+  order: optionalParam(
+    z.enum(["asc", "desc"], { error: "Order must be asc or desc." })
+  ).transform((v) => v ?? "desc"),
+});
+
+export type ListTicketsQuery = z.infer<typeof listTicketsQuerySchema>;

--- a/server/src/routes/tickets.routes.ts
+++ b/server/src/routes/tickets.routes.ts
@@ -1,8 +1,8 @@
 import { Router } from "express";
 import { asyncHandler } from "../lib/asyncHandler.js";
-import { createTicketSchema } from "../lib/validation.js";
+import { createTicketSchema, listTicketsQuerySchema } from "../lib/validation.js";
 import { requireRequester } from "../middleware/requireRequester.js";
-import { createTicket } from "../services/tickets.service.js";
+import { createTicket, listTickets } from "../services/tickets.service.js";
 
 export const ticketsRouter = Router();
 
@@ -16,5 +16,14 @@ ticketsRouter.post(
     const input = createTicketSchema.parse(req.body);
     const ticket = await createTicket(req.requester!.id, input);
     res.status(201).json(ticket);
+  })
+);
+
+ticketsRouter.get(
+  "/",
+  asyncHandler(async (req, res) => {
+    const query = listTicketsQuerySchema.parse(req.query);
+    const page = await listTickets(req.requester!.id, query);
+    res.status(200).json(page);
   })
 );

--- a/server/src/services/tickets.service.ts
+++ b/server/src/services/tickets.service.ts
@@ -2,7 +2,7 @@ import type { Prisma } from "@prisma/client";
 import { getPrisma } from "../prisma.js";
 import { HttpError, type FieldIssue } from "../lib/httpError.js";
 import { allocateTicketNumber } from "./ticketNumber.service.js";
-import type { CreateTicketInput } from "../lib/validation.js";
+import type { CreateTicketInput, ListTicketsQuery } from "../lib/validation.js";
 
 /** The relations every ticket-detail response includes. */
 const detailInclude = {
@@ -70,6 +70,68 @@ async function assertReferenceDataIsUsable(input: CreateTicketInput): Promise<vo
   if (details.length > 0) {
     throw HttpError.validationFailed("The submitted data is invalid.", details);
   }
+}
+
+const listSelect = {
+  id: true,
+  ticketNumber: true,
+  summary: true,
+  requestedPriority: true,
+  currentStatus: true,
+  createdAt: true,
+  category: { select: { id: true, name: true } },
+  relatedSystem: { select: { id: true, name: true } },
+  // Removed attachments do not count: the screen shows how many are usable.
+  _count: { select: { attachments: { where: { removedAt: null } } } },
+} satisfies Prisma.TicketSelect;
+
+export async function listTickets(requesterId: number, query: ListTicketsQuery) {
+  const prisma = getPrisma();
+
+  const where: Prisma.TicketWhereInput = {
+    // Not a filter the caller can influence — this is the ownership boundary.
+    requesterId,
+    ...(query.categoryId !== undefined && { categoryId: query.categoryId }),
+    ...(query.relatedSystemId !== undefined && { relatedSystemId: query.relatedSystemId }),
+    ...(query.priority !== undefined && { requestedPriority: query.priority }),
+    ...(query.q !== undefined && {
+      OR: [
+        { ticketNumber: { contains: query.q, mode: "insensitive" } },
+        { summary: { contains: query.q, mode: "insensitive" } },
+      ],
+    }),
+  };
+
+  // The secondary key is what keeps pagination stable: without it, rows that
+  // tie on the primary sort can move between pages, so one ticket appears
+  // twice and another never appears at all (BR-18).
+  const orderBy: Prisma.TicketOrderByWithRelationInput[] = [
+    { [query.sort]: query.order },
+    { id: "desc" },
+  ];
+
+  // One transaction so `total` always describes the same snapshot as `data`.
+  const [rows, total] = await prisma.$transaction([
+    prisma.ticket.findMany({
+      where,
+      select: listSelect,
+      orderBy,
+      skip: (query.page - 1) * query.pageSize,
+      take: query.pageSize,
+    }),
+    prisma.ticket.count({ where }),
+  ]);
+
+  return {
+    data: rows.map(({ _count, ...ticket }) => ({
+      ...ticket,
+      attachmentCount: _count.attachments,
+    })),
+    page: query.page,
+    pageSize: query.pageSize,
+    total,
+    totalPages: Math.ceil(total / query.pageSize),
+  };
 }
 
 export async function createTicket(requesterId: number, input: CreateTicketInput) {

--- a/server/tests/lab-02/my-tickets.api.test.ts
+++ b/server/tests/lab-02/my-tickets.api.test.ts
@@ -1,0 +1,387 @@
+import { randomUUID } from "node:crypto";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import request from "supertest";
+import { app } from "../../src/app.js";
+import { getPrisma } from "../../src/prisma.js";
+
+const prisma = getPrisma();
+const suiteTag = randomUUID();
+
+// Two requesters, so ownership isolation is asserted rather than assumed.
+let requesterA: number;
+let requesterB: number;
+let categoryHardware: number;
+let categorySoftware: number;
+let systemOne: number;
+let systemTwo: number;
+
+/** Tickets are created directly through Prisma so this suite does not depend on the create endpoint. */
+async function seedTicket(
+  requesterId: number,
+  overrides: Partial<{
+    summary: string;
+    categoryId: number;
+    relatedSystemId: number;
+    requestedPriority: "LOW" | "MEDIUM" | "HIGH" | "URGENT";
+    createdAt: Date;
+    ticketNumber: string;
+  }> = {}
+) {
+  return prisma.ticket.create({
+    data: {
+      ticketNumber: overrides.ticketNumber ?? `TKT-2026-${randomUUID().slice(0, 8)}`,
+      requesterId,
+      categoryId: overrides.categoryId ?? categoryHardware,
+      relatedSystemId: overrides.relatedSystemId ?? systemOne,
+      requestedPriority: overrides.requestedPriority ?? "MEDIUM",
+      summary: overrides.summary ?? "Placeholder summary for testing",
+      description: "A description long enough to satisfy the minimum length rule.",
+      ...(overrides.createdAt && { createdAt: overrides.createdAt }),
+    },
+  });
+}
+
+function list(requesterId: number, query: Record<string, string | number> = {}) {
+  return request(app)
+    .get("/api/tickets")
+    .query(query)
+    .set("X-Requester-Id", String(requesterId));
+}
+
+beforeAll(async () => {
+  const [a, b] = await Promise.all([
+    prisma.requesterUser.create({
+      data: { fullName: "List Suite A", email: `list-a-${suiteTag}@lab2.local` },
+    }),
+    prisma.requesterUser.create({
+      data: { fullName: "List Suite B", email: `list-b-${suiteTag}@lab2.local` },
+    }),
+  ]);
+  requesterA = a.id;
+  requesterB = b.id;
+
+  const categories = await prisma.category.findMany({ where: { active: true }, orderBy: { id: "asc" } });
+  const systems = await prisma.relatedSystem.findMany({ where: { active: true }, orderBy: { id: "asc" } });
+  categoryHardware = categories[0].id;
+  categorySoftware = categories[1].id;
+  systemOne = systems[0].id;
+  systemTwo = systems[1].id;
+
+  // Requester A: 12 tickets, enough for three pages of 5 and a partial last page.
+  // All share one createdAt so the stable-pagination test has real ties to break.
+  const tiedAt = new Date("2026-05-01T00:00:00.000Z");
+  for (let i = 1; i <= 12; i += 1) {
+    await seedTicket(requesterA, {
+      ticketNumber: `TKT-2026-90${String(i).padStart(4, "0")}`,
+      summary: `Shared tie summary ${i}`,
+      createdAt: tiedAt,
+    });
+  }
+
+  // Distinguishable tickets for search, filter and sort assertions.
+  await seedTicket(requesterA, {
+    ticketNumber: `TKT-2026-950001`,
+    summary: "Printer jams on duplex printing",
+    categoryId: categorySoftware,
+    relatedSystemId: systemTwo,
+    requestedPriority: "URGENT",
+    createdAt: new Date("2026-06-01T00:00:00.000Z"),
+  });
+  await seedTicket(requesterA, {
+    ticketNumber: `TKT-2026-950002`,
+    summary: "VPN disconnects every ten minutes",
+    categoryId: categorySoftware,
+    relatedSystemId: systemTwo,
+    requestedPriority: "LOW",
+    createdAt: new Date("2026-06-02T00:00:00.000Z"),
+  });
+
+  // Requester B owns one ticket that must never leak into A's results.
+  await seedTicket(requesterB, {
+    ticketNumber: `TKT-2026-960001`,
+    summary: "Belongs to requester B only",
+  });
+});
+
+afterAll(async () => {
+  await prisma.ticket.deleteMany({ where: { requesterId: { in: [requesterA, requesterB] } } });
+  await prisma.requesterUser.deleteMany({ where: { id: { in: [requesterA, requesterB] } } });
+  await prisma.$disconnect();
+});
+
+describe("GET /api/tickets — ownership", () => {
+  it("API-16: returns only the caller's own tickets", async () => {
+    const res = await list(requesterA, { pageSize: 50 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.total).toBe(14);
+    expect(res.body.data.every((t: any) => t.summary !== "Belongs to requester B only")).toBe(true);
+
+    const other = await list(requesterB, { pageSize: 50 });
+    expect(other.body.total).toBe(1);
+    expect(other.body.data[0].summary).toBe("Belongs to requester B only");
+  });
+
+  it("API-17: ignores a requesterId supplied as a query parameter", async () => {
+    // Ownership comes from the header alone. Supplying requesterId must not
+    // widen the result set to another requester's data (BR-16).
+    const res = await list(requesterB, { requesterId: requesterA, pageSize: 50 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.total).toBe(1);
+  });
+});
+
+describe("GET /api/tickets — search and filters", () => {
+  it("API-18: matches a ticket number case-insensitively", async () => {
+    const res = await list(requesterA, { q: "tkt-2026-950001" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.total).toBe(1);
+    expect(res.body.data[0].ticketNumber).toBe("TKT-2026-950001");
+  });
+
+  it("API-19: matches part of a summary case-insensitively", async () => {
+    const res = await list(requesterA, { q: "PRINTER" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.total).toBe(1);
+    expect(res.body.data[0].summary).toBe("Printer jams on duplex printing");
+  });
+
+  it("API-20: filters by category", async () => {
+    const res = await list(requesterA, { categoryId: categorySoftware, pageSize: 50 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.total).toBe(2);
+    expect(res.body.data.every((t: any) => t.category.id === categorySoftware)).toBe(true);
+  });
+
+  it("API-21: filters by related system", async () => {
+    const res = await list(requesterA, { relatedSystemId: systemTwo, pageSize: 50 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data.every((t: any) => t.relatedSystem.id === systemTwo)).toBe(true);
+  });
+
+  it("API-22: filters by requested priority", async () => {
+    const res = await list(requesterA, { priority: "URGENT", pageSize: 50 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.total).toBe(1);
+    expect(res.body.data[0].requestedPriority).toBe("URGENT");
+  });
+
+  it("API-23: combines filters conjunctively", async () => {
+    const both = await list(requesterA, {
+      categoryId: categorySoftware,
+      priority: "URGENT",
+      pageSize: 50,
+    });
+    expect(both.body.total).toBe(1);
+
+    // The same priority against the other category must match nothing.
+    const contradictory = await list(requesterA, {
+      categoryId: categoryHardware,
+      priority: "URGENT",
+      pageSize: 50,
+    });
+    expect(contradictory.body.total).toBe(0);
+  });
+
+  it("API-31: returns an empty page rather than an error when nothing matches", async () => {
+    const res = await list(requesterA, { q: "nothing-matches-this-string" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+    expect(res.body.total).toBe(0);
+    expect(res.body.totalPages).toBe(0);
+  });
+});
+
+describe("GET /api/tickets — sorting", () => {
+  it("API-25: defaults to newest first", async () => {
+    const res = await list(requesterA, { pageSize: 50 });
+
+    const dates = res.body.data.map((t: any) => new Date(t.createdAt).getTime());
+    expect([...dates]).toEqual([...dates].sort((x, y) => y - x));
+  });
+
+  it("API-24: sorts by each whitelisted field in both directions", async () => {
+    for (const sort of ["createdAt", "ticketNumber", "summary"]) {
+      const asc = await list(requesterA, { sort, order: "asc", pageSize: 50 });
+      const desc = await list(requesterA, { sort, order: "desc", pageSize: 50 });
+
+      expect(asc.status).toBe(200);
+      expect(desc.status).toBe(200);
+
+      const ascValues = asc.body.data.map((t: any) => t[sort]);
+      const descValues = desc.body.data.map((t: any) => t[sort]);
+      expect(ascValues).toEqual([...ascValues].sort());
+      expect(descValues).toEqual([...ascValues].sort().reverse());
+    }
+  });
+
+  it("API-24: orders priority by severity, not alphabetically", async () => {
+    const res = await list(requesterA, {
+      sort: "requestedPriority",
+      order: "asc",
+      pageSize: 50,
+    });
+
+    const priorities: string[] = res.body.data.map((t: any) => t.requestedPriority);
+    // Alphabetically LOW would follow HIGH; by severity it comes first. The
+    // enum is declared in severity order precisely so this holds.
+    expect(priorities[0]).toBe("LOW");
+    expect(priorities[priorities.length - 1]).toBe("URGENT");
+  });
+});
+
+describe("GET /api/tickets — pagination", () => {
+  it("API-27: pages are disjoint and total describes the whole result", async () => {
+    const first = await list(requesterA, { page: 1, pageSize: 10 });
+    const second = await list(requesterA, { page: 2, pageSize: 10 });
+
+    expect(first.body.total).toBe(14);
+    expect(first.body.totalPages).toBe(2);
+    expect(first.body.data).toHaveLength(10);
+    expect(second.body.data).toHaveLength(4); // partial last page
+
+    const firstIds = first.body.data.map((t: any) => t.id);
+    const secondIds = second.body.data.map((t: any) => t.id);
+    expect(firstIds.filter((id: number) => secondIds.includes(id))).toEqual([]);
+  });
+
+  it("API-26: pagination stays stable when the sort values tie", async () => {
+    // Twelve of the fourteen tickets share one createdAt, so the tie group
+    // straddles the page boundary. Without a secondary key the database is
+    // free to order ties differently per query, and a row can then appear on
+    // two pages while another appears on none (BR-18).
+    const seen: number[] = [];
+    for (const page of [1, 2]) {
+      const res = await list(requesterA, { page, pageSize: 10, sort: "createdAt", order: "desc" });
+      expect(res.status).toBe(200);
+      seen.push(...res.body.data.map((t: any) => t.id));
+    }
+
+    expect(seen).toHaveLength(14);
+    expect(new Set(seen).size).toBe(14);
+
+    // Absence of duplicates is necessary but not sufficient: at this data size
+    // PostgreSQL happens to return a consistent order even with no secondary
+    // key, so that assertion alone passes whether or not the key is present.
+    // This asserts the tie-break directly — within the tied group the ids must
+    // descend, which is only true because `id: "desc"` is applied.
+    const tied = await list(requesterA, {
+      pageSize: 50,
+      sort: "createdAt",
+      order: "desc",
+      q: "Shared tie summary",
+    });
+    const tiedIds: number[] = tied.body.data.map((t: any) => t.id);
+    expect(tiedIds).toHaveLength(12);
+    expect(tiedIds).toEqual([...tiedIds].sort((x, y) => y - x));
+  });
+
+  it("returns an empty page beyond the last one", async () => {
+    const res = await list(requesterA, { page: 99, pageSize: 10 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data).toEqual([]);
+    expect(res.body.total).toBe(14);
+  });
+});
+
+describe("GET /api/tickets — attachment count", () => {
+  it("API-32: counts only active attachments", async () => {
+    const ticket = await seedTicket(requesterA, {
+      ticketNumber: "TKT-2026-970001",
+      summary: "Ticket used for attachment counting",
+    });
+    await prisma.attachment.createMany({
+      data: [
+        {
+          ticketId: ticket.id,
+          originalFilename: "active.png",
+          storedFilename: `${randomUUID()}.png`,
+          mimeType: "image/png",
+          sizeBytes: 1024,
+          uploadedByRequesterId: requesterA,
+        },
+        {
+          ticketId: ticket.id,
+          originalFilename: "removed.png",
+          storedFilename: `${randomUUID()}.png`,
+          mimeType: "image/png",
+          sizeBytes: 1024,
+          uploadedByRequesterId: requesterA,
+          removedAt: new Date(),
+          removedByRequesterId: requesterA,
+          removalReason: "Uploaded the wrong file",
+        },
+      ],
+    });
+
+    const res = await list(requesterA, { q: "attachment counting" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.data[0].attachmentCount).toBe(1);
+
+    await prisma.attachment.deleteMany({ where: { ticketId: ticket.id } });
+    await prisma.ticket.delete({ where: { id: ticket.id } });
+  });
+});
+
+describe("GET /api/tickets — invalid parameters", () => {
+  it("UNIT-02 / API-28: rejects a page size outside the permitted set", async () => {
+    const res = await list(requesterA, { pageSize: 7 });
+
+    // Rejected, not silently clamped: a specified 400 is testable, a silent
+    // substitution is not (BR-20).
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_FAILED");
+  });
+
+  it("API-29: rejects page 0, since pages are numbered from 1", async () => {
+    const res = await list(requesterA, { page: 0 });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_FAILED");
+  });
+
+  it("API-30: rejects a sort field outside the whitelist", async () => {
+    const res = await list(requesterA, { sort: "password" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_FAILED");
+  });
+
+  it("rejects an unknown order direction", async () => {
+    const res = await list(requesterA, { order: "sideways" });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects an unknown priority", async () => {
+    const res = await list(requesterA, { priority: "CRITICAL" });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("UNIT-02: applies defaults when no parameters are supplied", async () => {
+    const res = await list(requesterA);
+
+    expect(res.status).toBe(200);
+    expect(res.body.page).toBe(1);
+    expect(res.body.pageSize).toBe(10);
+  });
+});
+
+describe("GET /api/tickets — requester identity", () => {
+  it("rejects a request with no identity header", async () => {
+    const res = await request(app).get("/api/tickets");
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("REQUESTER_HEADER_MISSING");
+  });
+});


### PR DESCRIPTION
…tion

Add GET /api/tickets. Ownership is part of the where clause rather than an accepted parameter, so a caller cannot widen the result set to someone else's tickets. Invalid query parameters are rejected rather than clamped, because a silent substitution cannot be asserted by a test.

Every sort appends id descending. Without it, rows that tie on the primary sort can move between pages, so one ticket appears twice and another never appears at all.

The stability test initially passed with the secondary key removed, because PostgreSQL happens to return a consistent order for a table this small, so asserting only the absence of duplicates proved nothing. It now asserts the tie-break directly: within a group sharing one createdAt, ids must descend. That assertion fails when the key is removed, which was verified.

Data and total are read in one transaction so the count always describes the page that was returned, and the attachment count excludes removed rows.