### PR TITLE
Attachments API with soft removal and orphan cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ dist/
 build/
 # prisma
 server/prisma/*.db
+# uploaded attachments — the directory must exist on a fresh clone, its contents must not be committed
+server/uploads/*
+!server/uploads/.gitkeep
 # logs & OS
 *.log
 .DS_Store

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -37,7 +37,7 @@ Status column: `Planned` until implemented, then `Pass`.
 |---|---|---|---|---|---|---|
 | UNIT-01 | Unit | BR-01, AC-09 | Ticket number formatter | `format(2026, 42)` returns `TKT-2026-000042` | `server/tests/lab-02/create-ticket.api.test.ts` | Pass |
 | UNIT-02 | Unit | BR-19, BR-20 | Ticket list query schema | `pageSize=7` and `page=0` are rejected; defaults applied when absent | `server/tests/lab-02/my-tickets.api.test.ts` | Pass |
-| UNIT-03 | Unit | BR-29 | Attachment type check | Permitted extension + MIME accepted; either one wrong rejected | `server/tests/lab-02/attachments.api.test.ts` | Planned |
+| UNIT-03 | Unit | BR-29 | Attachment type check | Permitted extension + MIME accepted; either one wrong rejected | `server/tests/lab-02/attachments.api.test.ts` | Pass |
 | UNIT-04 | Unit | BR-21, BR-22 | Trimming before validation | `"  hi  "` fails the 5-character minimum after trimming | `server/tests/lab-02/create-ticket.api.test.ts` | Pass |
 
 ### 2.2 API — create ticket
@@ -107,25 +107,25 @@ File: `server/tests/lab-02/attachments.api.test.ts`
 
 | Test ID | Type | Requirement / AC | What it tests | Expected result | Final |
 |---|---|---|---|---|---|
-| API-39 | API | AC-32 | Upload each permitted type | 201 for JPEG, PNG, WEBP, and PDF | Planned |
-| API-40 | API | AC-33, BR-30 | 6 MB file | 413 `FILE_TOO_LARGE`; no row and no file left behind | Planned |
-| API-41 | API | AC-34, BR-29 | Disallowed extension | 415 `UNSUPPORTED_FILE_TYPE` | Planned |
-| API-42 | API | BR-29 | Permitted extension with a disallowed MIME type | 415 — both checks must pass | Planned |
-| API-43 | API | AC-35, BR-31 | Sixth active attachment | 409 `ATTACHMENT_LIMIT_REACHED` | Planned |
-| API-44 | API | AC-36, BR-31 | Upload after removing one of five | 201 — removed attachments do not count | Planned |
-| API-45 | API | BR-38 | Non-owner uploads | 404 `TICKET_NOT_FOUND` | Planned |
-| API-46 | API | §6.1 | Request with no file part | 400 `NO_FILE` | Planned |
-| API-47 | API | BR-36 | Filename `../../evil.png` | Stored under a generated UUID name inside the upload directory; original kept only as metadata | Planned |
-| API-48 | API | BR-40 | Rejected upload cleanup | No orphan file remains after a 409 or 415 | Planned |
-| API-49 | API | AC-37 | Download an active attachment | 200 with the correct `Content-Type` and the original filename in `Content-Disposition` | Planned |
-| API-50 | API | AC-39, BR-33 | **Download a removed attachment** | **410 `ATTACHMENT_REMOVED`**; no content returned | Planned |
-| API-51 | API | BR-38 | Non-owner downloads | 404 | Planned |
-| API-52 | API | AC-38, BR-32 | Soft removal | 200; `removedAt`, `removalReason`, and remover recorded; row still present | Planned |
-| API-53 | API | AC-40, BR-34 | Removal without a reason | 400 | Planned |
-| API-54 | API | BR-34 | Removal reason of 2 characters | 400 | Planned |
-| API-55 | API | AC-41, BR-35 | Removing twice | 409 `ALREADY_REMOVED` | Planned |
-| API-56 | API | AC-42, BR-38 | Non-owner reads metadata or removes | 404 for both | Planned |
-| API-57 | API | BR-32 | The file survives removal | The stored file is still on disk after a soft removal | Planned |
+| API-39 | API | AC-32 | Upload each permitted type | 201 for JPEG, PNG, WEBP, and PDF | Pass |
+| API-40 | API | AC-33, BR-30 | 6 MB file | 413 `FILE_TOO_LARGE`; no row and no file left behind | Pass |
+| API-41 | API | AC-34, BR-29 | Disallowed extension | 415 `UNSUPPORTED_FILE_TYPE` | Pass |
+| API-42 | API | BR-29 | Permitted extension with a disallowed MIME type | 415 — both checks must pass | Pass |
+| API-43 | API | AC-35, BR-31 | Sixth active attachment | 409 `ATTACHMENT_LIMIT_REACHED` | Pass |
+| API-44 | API | AC-36, BR-31 | Upload after removing one of five | 201 — removed attachments do not count | Pass |
+| API-45 | API | BR-38 | Non-owner uploads | 404 `TICKET_NOT_FOUND` | Pass |
+| API-46 | API | §6.1 | Request with no file part | 400 `NO_FILE` | Pass |
+| API-47 | API | BR-36 | Filename `../../evil.png` | Stored under a generated UUID name inside the upload directory; original kept only as metadata | Pass |
+| API-48 | API | BR-40 | Rejected upload cleanup | No orphan file remains after a 409 or 415 | Pass |
+| API-49 | API | AC-37 | Download an active attachment | 200 with the correct `Content-Type` and the original filename in `Content-Disposition` | Pass |
+| API-50 | API | AC-39, BR-33 | **Download a removed attachment** | **410 `ATTACHMENT_REMOVED`**; no content returned | Pass |
+| API-51 | API | BR-38 | Non-owner downloads | 404 | Pass |
+| API-52 | API | AC-38, BR-32 | Soft removal | 200; `removedAt`, `removalReason`, and remover recorded; row still present | Pass |
+| API-53 | API | AC-40, BR-34 | Removal without a reason | 400 | Pass |
+| API-54 | API | BR-34 | Removal reason of 2 characters | 400 | Pass |
+| API-55 | API | AC-41, BR-35 | Removing twice | 409 `ALREADY_REMOVED` | Pass |
+| API-56 | API | AC-42, BR-38 | Non-owner reads metadata or removes | 404 for both | Pass |
+| API-57 | API | BR-32 | The file survives removal | The stored file is still on disk after a soft removal | Pass |
 
 ### 2.6 UI components
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,8 +9,10 @@
       "version": "1.0.0",
       "dependencies": {
         "@prisma/client": "^5.22.0",
+        "@types/multer": "^2.2.0",
         "cors": "^2.8.5",
         "express": "^4.21.2",
+        "multer": "^2.3.0",
         "zod": "^4.5.4"
       },
       "devDependencies": {
@@ -978,7 +980,6 @@
       "version": "1.19.6",
       "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
       "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/connect": "*",
@@ -989,7 +990,6 @@
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
       "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -1023,7 +1023,6 @@
       "version": "4.17.25",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
       "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/body-parser": "*",
@@ -1036,7 +1035,6 @@
       "version": "4.19.9",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.9.tgz",
       "integrity": "sha512-QP2ESEe/ImWY0HDwNAnK9PvEffUyhLTnWkk7KXzHfyeWAnlrDe1fN77bXl6ia8KT3wPlmA7t9/VPRpnf4Ex9sg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -1049,7 +1047,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
       "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/methods": {
@@ -1063,14 +1060,21 @@
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
       "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/multer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/multer/-/multer-2.2.0.tgz",
+      "integrity": "sha512-3U1troeqGV8Ntp7Q3klwf4zr23VEoqYVocYXaswm9+8z3O9UHDYAqLxjJ/h550iRADTjKdOdhhasXw6gD6kYtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "22.20.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
       "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -1080,21 +1084,18 @@
       "version": "6.15.1",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
       "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
       "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -1104,7 +1105,6 @@
       "version": "1.15.10",
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
       "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/http-errors": "*",
@@ -1116,7 +1116,6 @@
       "version": "0.17.6",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
       "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/mime": "^1",
@@ -1273,6 +1272,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
+      "license": "MIT"
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -1325,6 +1330,23 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
       }
     },
     "node_modules/bytes": {
@@ -1423,6 +1445,21 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
       }
     },
     "node_modules/content-disposition": {
@@ -2078,6 +2115,25 @@
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
     },
+    "node_modules/multer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.3.0.tgz",
+      "integrity": "sha512-cjNbm3sttszgZeGfJR124D+jFEfkXCVAsoPBmFn9X7UxmDSFHWqE2CoEj0vrmSpuAFnqWR1Szcm9QTsiHr60Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
+      },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.18",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
@@ -2288,6 +2344,20 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/rollup": {
@@ -2525,6 +2595,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/superagent": {
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
@@ -2694,6 +2781,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -2712,7 +2805,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -2723,6 +2815,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",

--- a/server/package.json
+++ b/server/package.json
@@ -16,8 +16,10 @@
   },
   "dependencies": {
     "@prisma/client": "^5.22.0",
+    "@types/multer": "^2.2.0",
     "cors": "^2.8.5",
     "express": "^4.21.2",
+    "multer": "^2.3.0",
     "zod": "^4.5.4"
   },
   "devDependencies": {

--- a/server/src/lib/paths.ts
+++ b/server/src/lib/paths.ts
@@ -1,0 +1,27 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * server/uploads. The directory is gitignored but must exist on a fresh clone,
+ * so a .gitkeep is committed and it is also created at boot — belt and braces,
+ * because the first upload otherwise fails with ENOENT.
+ */
+export const UPLOAD_DIR = path.resolve(here, "..", "..", "uploads");
+
+export function ensureUploadDir(): void {
+  fs.mkdirSync(UPLOAD_DIR, { recursive: true });
+}
+
+export function storedFilePath(storedFilename: string): string {
+  // storedFilename is always a server-generated UUID plus an extension, never
+  // anything the requester supplied, so it cannot escape UPLOAD_DIR (BR-36).
+  return path.join(UPLOAD_DIR, storedFilename);
+}
+
+/** Deletes a file if it is there, ignoring the case where it is not. */
+export async function deleteFileIfPresent(absolutePath: string): Promise<void> {
+  await fs.promises.rm(absolutePath, { force: true });
+}

--- a/server/src/lib/validation.ts
+++ b/server/src/lib/validation.ts
@@ -43,6 +43,15 @@ export const idParamSchema = z.object({
     .transform(Number),
 });
 
+/** A reason is required so the removal is explainable to whoever reads it later (BR-34). */
+export const removeAttachmentSchema = z.object({
+  removalReason: z
+    .string({ error: "A removal reason is required." })
+    .trim()
+    .min(3, "The removal reason must be at least 3 characters.")
+    .max(200, "The removal reason must be at most 200 characters."),
+});
+
 export const TICKET_SORT_FIELDS = [
   "createdAt",
   "ticketNumber",

--- a/server/src/middleware/errorHandler.ts
+++ b/server/src/middleware/errorHandler.ts
@@ -1,6 +1,8 @@
 import type { NextFunction, Request, Response } from "express";
+import { MulterError } from "multer";
 import { ZodError } from "zod";
 import { HttpError, type FieldIssue } from "../lib/httpError.js";
+import { MAX_ATTACHMENT_BYTES } from "./upload.js";
 
 function zodIssues(error: ZodError): FieldIssue[] {
   return error.issues.map((issue) => ({
@@ -27,6 +29,24 @@ export function errorHandler(
   if (err instanceof HttpError) {
     res.status(err.status).json({
       error: { code: err.code, message: err.message, ...(err.details && { details: err.details }) },
+    });
+    return;
+  }
+
+  // Multer signals its own limits with a MulterError rather than an HttpError,
+  // so without this mapping an oversized upload would surface as a 500.
+  if (err instanceof MulterError) {
+    if (err.code === "LIMIT_FILE_SIZE") {
+      res.status(413).json({
+        error: {
+          code: "FILE_TOO_LARGE",
+          message: `Each attachment must be ${MAX_ATTACHMENT_BYTES / (1024 * 1024)} MB or smaller.`,
+        },
+      });
+      return;
+    }
+    res.status(400).json({
+      error: { code: "NO_FILE", message: "The uploaded file could not be read." },
     });
     return;
   }

--- a/server/src/middleware/upload.ts
+++ b/server/src/middleware/upload.ts
@@ -1,0 +1,60 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import multer from "multer";
+import { HttpError } from "../lib/httpError.js";
+import { UPLOAD_DIR, ensureUploadDir } from "../lib/paths.js";
+
+export const MAX_ATTACHMENT_BYTES = 5 * 1024 * 1024;
+export const MAX_ACTIVE_ATTACHMENTS = 5;
+
+const ALLOWED_EXTENSIONS = new Set([".jpg", ".jpeg", ".png", ".webp", ".pdf"]);
+const ALLOWED_MIME_TYPES = new Set([
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "application/pdf",
+]);
+
+/**
+ * Both the extension and the declared MIME type must be permitted. Neither is
+ * authoritative on its own — the browser supplies the MIME type and a user can
+ * rename a file — so requiring both raises the bar without pretending to be
+ * content inspection, which is out of scope for Lab 2 (BR-29, D-11).
+ */
+export function isPermittedFile(originalName: string, mimeType: string): boolean {
+  return (
+    ALLOWED_EXTENSIONS.has(path.extname(originalName).toLowerCase()) &&
+    ALLOWED_MIME_TYPES.has(mimeType)
+  );
+}
+
+ensureUploadDir();
+
+const storage = multer.diskStorage({
+  destination: (_req, _file, cb) => cb(null, UPLOAD_DIR),
+  filename: (_req, file, cb) => {
+    // Never derive the stored name from the requester's filename: a name such
+    // as "../../etc/passwd" would otherwise escape the upload directory.
+    cb(null, `${randomUUID()}${path.extname(file.originalname).toLowerCase()}`);
+  },
+});
+
+export const uploadSingleAttachment = multer({
+  storage,
+  limits: { fileSize: MAX_ATTACHMENT_BYTES, files: 1 },
+  fileFilter: (_req, file, cb) => {
+    if (!isPermittedFile(file.originalname, file.mimetype)) {
+      // Rejecting here means the file is never written, so a wrong type leaves
+      // no orphan to clean up.
+      cb(
+        new HttpError(
+          415,
+          "UNSUPPORTED_FILE_TYPE",
+          "Only JPG, JPEG, PNG, WEBP and PDF files are accepted."
+        )
+      );
+      return;
+    }
+    cb(null, true);
+  },
+}).single("file");

--- a/server/src/routes/attachments.routes.ts
+++ b/server/src/routes/attachments.routes.ts
@@ -1,0 +1,68 @@
+import { Router } from "express";
+import { asyncHandler } from "../lib/asyncHandler.js";
+import { HttpError } from "../lib/httpError.js";
+import { idParamSchema, removeAttachmentSchema } from "../lib/validation.js";
+import { requireRequester } from "../middleware/requireRequester.js";
+import {
+  getAttachmentMetadata,
+  getDownloadableAttachment,
+  removeAttachment,
+} from "../services/attachments.service.js";
+
+export const attachmentsRouter = Router();
+
+attachmentsRouter.use(requireRequester);
+
+attachmentsRouter.get(
+  "/:id",
+  asyncHandler(async (req, res) => {
+    const { id } = idParamSchema.parse(req.params);
+    res.status(200).json(await getAttachmentMetadata(req.requester!.id, id));
+  })
+);
+
+attachmentsRouter.get(
+  "/:id/download",
+  asyncHandler(async (req, res) => {
+    const { id } = idParamSchema.parse(req.params);
+    const file = await getDownloadableAttachment(req.requester!.id, id);
+
+    res.setHeader("Content-Type", file.mimeType);
+    res.setHeader("Content-Length", String(file.sizeBytes));
+    // The stored name is internal; the requester gets the name they uploaded.
+    res.setHeader(
+      "Content-Disposition",
+      `attachment; filename="${file.originalFilename.replace(/"/g, "")}"`
+    );
+    res.setHeader("X-Content-Type-Options", "nosniff");
+
+    await new Promise<void>((resolve, reject) => {
+      res.sendFile(file.absolutePath, (error) => {
+        if (!error) {
+          resolve();
+          return;
+        }
+        // The row exists but the bytes do not — a server-side inconsistency,
+        // not something the caller did wrong.
+        reject(
+          new HttpError(
+            500,
+            "ATTACHMENT_FILE_MISSING",
+            "The stored file for this attachment could not be read."
+          )
+        );
+      });
+    });
+  })
+);
+
+// PATCH, not DELETE: the attachment is not deleted and stays addressable
+// afterwards, so DELETE would imply a subsequent 404 that does not happen (D-04).
+attachmentsRouter.patch(
+  "/:id/remove",
+  asyncHandler(async (req, res) => {
+    const { id } = idParamSchema.parse(req.params);
+    const { removalReason } = removeAttachmentSchema.parse(req.body);
+    res.status(200).json(await removeAttachment(req.requester!.id, id, removalReason));
+  })
+);

--- a/server/src/routes/index.ts
+++ b/server/src/routes/index.ts
@@ -2,9 +2,11 @@ import { Router } from "express";
 import { relatedSystemsRouter } from "./relatedSystems.routes.js";
 import { requestersRouter } from "./requesters.routes.js";
 import { ticketsRouter } from "./tickets.routes.js";
+import { attachmentsRouter } from "./attachments.routes.js";
 
 export const apiRouter = Router();
 
 apiRouter.use("/related-systems", relatedSystemsRouter);
 apiRouter.use("/dev-requesters", requestersRouter);
 apiRouter.use("/tickets", ticketsRouter);
+apiRouter.use("/attachments", attachmentsRouter);

--- a/server/src/routes/tickets.routes.ts
+++ b/server/src/routes/tickets.routes.ts
@@ -1,8 +1,11 @@
 import { Router } from "express";
 import { asyncHandler } from "../lib/asyncHandler.js";
+import { HttpError } from "../lib/httpError.js";
 import { createTicketSchema, idParamSchema, listTicketsQuerySchema } from "../lib/validation.js";
 import { requireRequester } from "../middleware/requireRequester.js";
+import { uploadSingleAttachment } from "../middleware/upload.js";
 import { createTicket, getOwnedTicket, listTickets } from "../services/tickets.service.js";
+import { addAttachment, assertTicketIsOwned } from "../services/attachments.service.js";
 
 export const ticketsRouter = Router();
 
@@ -34,5 +37,24 @@ ticketsRouter.get(
     const { id } = idParamSchema.parse(req.params);
     const ticket = await getOwnedTicket(req.requester!.id, id);
     res.status(200).json(ticket);
+  })
+);
+
+ticketsRouter.post(
+  "/:id/attachments",
+  // Ownership is checked before multer runs, so a file is never written to
+  // disk for a ticket the caller does not own — one fewer orphan case.
+  asyncHandler(async (req, _res, next) => {
+    const { id } = idParamSchema.parse(req.params);
+    await assertTicketIsOwned(req.requester!.id, id);
+    next();
+  }),
+  uploadSingleAttachment,
+  asyncHandler(async (req, res) => {
+    if (!req.file) {
+      throw HttpError.badRequest("NO_FILE", "No file was included in the request.");
+    }
+    const { id } = idParamSchema.parse(req.params);
+    res.status(201).json(await addAttachment(req.requester!.id, id, req.file));
   })
 );

--- a/server/src/services/attachments.service.ts
+++ b/server/src/services/attachments.service.ts
@@ -1,0 +1,131 @@
+import { getPrisma } from "../prisma.js";
+import { HttpError } from "../lib/httpError.js";
+import { deleteFileIfPresent, storedFilePath } from "../lib/paths.js";
+import { MAX_ACTIVE_ATTACHMENTS } from "../middleware/upload.js";
+import { serializeAttachment } from "./tickets.service.js";
+
+/**
+ * Resolves a ticket the caller owns, or refuses. Used before an upload so that
+ * no file is written for a ticket that is not the caller's.
+ *
+ * Like ticket detail, a ticket owned by someone else is reported as not found
+ * rather than forbidden, so ids cannot be enumerated (BR-13).
+ */
+export async function assertTicketIsOwned(requesterId: number, ticketId: number): Promise<void> {
+  const ticket = await getPrisma().ticket.findFirst({
+    where: { id: ticketId, requesterId },
+    select: { id: true },
+  });
+
+  if (!ticket) {
+    throw HttpError.notFound("TICKET_NOT_FOUND", "The requested ticket does not exist.");
+  }
+}
+
+/** Loads an attachment only if the caller owns its parent ticket. */
+async function findOwnedAttachment(requesterId: number, attachmentId: number) {
+  const attachment = await getPrisma().attachment.findFirst({
+    where: { id: attachmentId, ticket: { requesterId } },
+  });
+
+  if (!attachment) {
+    throw HttpError.notFound("ATTACHMENT_NOT_FOUND", "The requested attachment does not exist.");
+  }
+
+  return attachment;
+}
+
+export async function addAttachment(
+  requesterId: number,
+  ticketId: number,
+  file: Express.Multer.File
+) {
+  const prisma = getPrisma();
+
+  try {
+    // Counting and inserting share a transaction. "At most five active" is a
+    // count, not a uniqueness property, so no database constraint expresses it
+    // — it is an application-level invariant (BR-31).
+    const created = await prisma.$transaction(async (tx) => {
+      const activeCount = await tx.attachment.count({
+        where: { ticketId, removedAt: null },
+      });
+
+      if (activeCount >= MAX_ACTIVE_ATTACHMENTS) {
+        throw HttpError.conflict(
+          "ATTACHMENT_LIMIT_REACHED",
+          `A ticket may have at most ${MAX_ACTIVE_ATTACHMENTS} active attachments.`
+        );
+      }
+
+      return tx.attachment.create({
+        data: {
+          ticketId,
+          originalFilename: file.originalname,
+          storedFilename: file.filename,
+          mimeType: file.mimetype,
+          sizeBytes: file.size,
+          uploadedByRequesterId: requesterId,
+        },
+      });
+    });
+
+    return serializeAttachment(created);
+  } catch (error) {
+    // The file reached disk before this handler ran, so a rejection here would
+    // otherwise leave it orphaned with no row pointing at it (BR-40).
+    await deleteFileIfPresent(storedFilePath(file.filename));
+    throw error;
+  }
+}
+
+export async function getAttachmentMetadata(requesterId: number, attachmentId: number) {
+  // Works for removed attachments too: their metadata stays visible, only the
+  // content becomes unreachable.
+  return serializeAttachment(await findOwnedAttachment(requesterId, attachmentId));
+}
+
+export async function getDownloadableAttachment(requesterId: number, attachmentId: number) {
+  const attachment = await findOwnedAttachment(requesterId, attachmentId);
+
+  if (attachment.removedAt !== null) {
+    // 410 rather than 404 here: the caller owns this attachment and already
+    // knows it exists from the ticket detail response, so nothing leaks, and a
+    // precise status lets the client say why (api-spec §3).
+    throw HttpError.gone("ATTACHMENT_REMOVED", "This attachment was removed and can no longer be downloaded.");
+  }
+
+  return {
+    absolutePath: storedFilePath(attachment.storedFilename),
+    originalFilename: attachment.originalFilename,
+    mimeType: attachment.mimeType,
+    sizeBytes: attachment.sizeBytes,
+  };
+}
+
+export async function removeAttachment(
+  requesterId: number,
+  attachmentId: number,
+  removalReason: string
+) {
+  const attachment = await findOwnedAttachment(requesterId, attachmentId);
+
+  if (attachment.removedAt !== null) {
+    // A silently idempotent 200 would hide a double submission from the caller
+    // and from the tests (BR-35).
+    throw HttpError.conflict("ALREADY_REMOVED", "This attachment has already been removed.");
+  }
+
+  // Soft removal: the row stays and the bytes stay on disk. Only access is
+  // revoked (BR-32).
+  const updated = await getPrisma().attachment.update({
+    where: { id: attachmentId },
+    data: {
+      removedAt: new Date(),
+      removedByRequesterId: requesterId,
+      removalReason,
+    },
+  });
+
+  return serializeAttachment(updated);
+}

--- a/server/tests/lab-02/attachments.api.test.ts
+++ b/server/tests/lab-02/attachments.api.test.ts
@@ -1,0 +1,400 @@
+import fs from "node:fs";
+import { randomUUID } from "node:crypto";
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import request from "supertest";
+import { app } from "../../src/app.js";
+import { getPrisma } from "../../src/prisma.js";
+import { UPLOAD_DIR, storedFilePath } from "../../src/lib/paths.js";
+import { isPermittedFile, MAX_ATTACHMENT_BYTES } from "../../src/middleware/upload.js";
+
+const prisma = getPrisma();
+const suiteTag = randomUUID();
+
+let ownerId: number;
+let strangerId: number;
+let ticketId: number;
+let strangerTicketId: number;
+
+// A tiny but valid-looking payload; the API validates the extension and the
+// declared MIME type, not the bytes (D-11).
+const PNG_BYTES = Buffer.from("89504e470d0a1a0a0000000d49484452", "hex");
+
+function upload(
+  target: number,
+  filename: string,
+  contentType: string,
+  bytes: Buffer = PNG_BYTES,
+  requesterId: number = ownerId
+) {
+  return (
+    request(app)
+      .post(`/api/tickets/${target}/attachments`)
+      .set("X-Requester-Id", String(requesterId))
+      // Never set Content-Type by hand here: supertest owns the multipart
+      // boundary, and overriding it corrupts the body.
+      .attach("file", bytes, { filename, contentType })
+  );
+}
+
+async function uploadedFilenames(): Promise<string[]> {
+  const entries = await fs.promises.readdir(UPLOAD_DIR);
+  return entries.filter((name) => name !== ".gitkeep");
+}
+
+/** Creates a ticket owned by `requesterId` directly, bypassing the create endpoint. */
+async function makeTicket(requesterId: number, summary: string) {
+  const category = await prisma.category.findFirstOrThrow({ where: { active: true } });
+  const relatedSystem = await prisma.relatedSystem.findFirstOrThrow({ where: { active: true } });
+  return prisma.ticket.create({
+    data: {
+      ticketNumber: `TKT-2026-${randomUUID().slice(0, 8)}`,
+      requesterId,
+      categoryId: category.id,
+      relatedSystemId: relatedSystem.id,
+      requestedPriority: "MEDIUM",
+      summary,
+      description: "A description long enough to satisfy the minimum length rule.",
+    },
+  });
+}
+
+beforeAll(async () => {
+  const [owner, stranger] = await Promise.all([
+    prisma.requesterUser.create({
+      data: { fullName: "Attach Owner", email: `attach-owner-${suiteTag}@lab2.local` },
+    }),
+    prisma.requesterUser.create({
+      data: { fullName: "Attach Stranger", email: `attach-stranger-${suiteTag}@lab2.local` },
+    }),
+  ]);
+  ownerId = owner.id;
+  strangerId = stranger.id;
+
+  strangerTicketId = (await makeTicket(strangerId, "Stranger ticket")).id;
+});
+
+beforeEach(async () => {
+  // A fresh ticket per test, so the five-attachment limit and the counts are
+  // never affected by what an earlier test left behind.
+  ticketId = (await makeTicket(ownerId, "Attachment target ticket")).id;
+});
+
+afterAll(async () => {
+  // Delete the stored files this suite wrote before dropping the rows that
+  // name them, or the filenames are lost and the files leak.
+  const attachments = await prisma.attachment.findMany({
+    where: { ticket: { requesterId: { in: [ownerId, strangerId] } } },
+    select: { storedFilename: true },
+  });
+  await Promise.all(
+    attachments.map((a) => fs.promises.rm(storedFilePath(a.storedFilename), { force: true }))
+  );
+
+  await prisma.attachment.deleteMany({
+    where: { ticket: { requesterId: { in: [ownerId, strangerId] } } },
+  });
+  await prisma.ticket.deleteMany({ where: { requesterId: { in: [ownerId, strangerId] } } });
+  await prisma.requesterUser.deleteMany({ where: { id: { in: [ownerId, strangerId] } } });
+  await prisma.$disconnect();
+});
+
+describe("Attachment type rules", () => {
+  it("UNIT-03: accepts a permitted extension with a matching MIME type", () => {
+    expect(isPermittedFile("photo.PNG", "image/png")).toBe(true);
+    expect(isPermittedFile("scan.pdf", "application/pdf")).toBe(true);
+    expect(isPermittedFile("shot.jpeg", "image/jpeg")).toBe(true);
+    expect(isPermittedFile("art.webp", "image/webp")).toBe(true);
+  });
+
+  it("UNIT-03: rejects when either the extension or the MIME type is wrong", () => {
+    // Both must pass, so a renamed file and a spoofed type each fail.
+    expect(isPermittedFile("payload.exe", "application/octet-stream")).toBe(false);
+    expect(isPermittedFile("payload.exe", "image/png")).toBe(false);
+    expect(isPermittedFile("photo.png", "text/plain")).toBe(false);
+  });
+});
+
+describe("POST /api/tickets/:id/attachments — upload", () => {
+  it("API-39: accepts each permitted file type", async () => {
+    const cases: [string, string][] = [
+      ["evidence.png", "image/png"],
+      ["evidence.jpg", "image/jpeg"],
+      ["evidence.webp", "image/webp"],
+      ["evidence.pdf", "application/pdf"],
+    ];
+
+    for (const [filename, contentType] of cases) {
+      const res = await upload(ticketId, filename, contentType);
+      expect(res.status).toBe(201);
+      expect(res.body.originalFilename).toBe(filename);
+      expect(res.body.isRemoved).toBe(false);
+    }
+  });
+
+  it("API-40: refuses a file larger than the maximum and leaves nothing behind", async () => {
+    const before = await uploadedFilenames();
+    const oversized = Buffer.alloc(MAX_ATTACHMENT_BYTES + 1024);
+
+    const res = await upload(ticketId, "huge.png", "image/png", oversized);
+
+    expect(res.status).toBe(413);
+    expect(res.body.error.code).toBe("FILE_TOO_LARGE");
+    expect(await prisma.attachment.count({ where: { ticketId } })).toBe(0);
+    expect(await uploadedFilenames()).toEqual(before);
+  });
+
+  it("API-41: refuses a disallowed extension", async () => {
+    const res = await upload(ticketId, "payload.exe", "application/octet-stream");
+
+    expect(res.status).toBe(415);
+    expect(res.body.error.code).toBe("UNSUPPORTED_FILE_TYPE");
+    expect(await prisma.attachment.count({ where: { ticketId } })).toBe(0);
+  });
+
+  it("API-42: refuses a permitted extension carrying a disallowed MIME type", async () => {
+    const res = await upload(ticketId, "sneaky.png", "text/plain");
+
+    expect(res.status).toBe(415);
+    expect(await prisma.attachment.count({ where: { ticketId } })).toBe(0);
+  });
+
+  it("API-46: refuses a request with no file part", async () => {
+    const res = await request(app)
+      .post(`/api/tickets/${ticketId}/attachments`)
+      .set("X-Requester-Id", String(ownerId))
+      .field("unrelated", "value");
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("NO_FILE");
+  });
+
+  it("API-47: stores under a generated name, keeping the requester's name as metadata only", async () => {
+    const res = await upload(ticketId, "../../escape-attempt.png", "image/png");
+
+    expect(res.status).toBe(201);
+
+    const saved = await prisma.attachment.findUniqueOrThrow({ where: { id: res.body.id } });
+    // A traversal sequence in the requester's filename must not reach the path.
+    expect(saved.storedFilename).toMatch(/^[0-9a-f-]{36}\.png$/);
+    expect(saved.storedFilename).not.toContain("..");
+    expect(fs.existsSync(storedFilePath(saved.storedFilename))).toBe(true);
+    // The internal name is never serialised to the client.
+    expect(res.body).not.toHaveProperty("storedFilename");
+  });
+
+  it("API-43: refuses a sixth active attachment", async () => {
+    for (let i = 0; i < 5; i += 1) {
+      expect((await upload(ticketId, `file-${i}.png`, "image/png")).status).toBe(201);
+    }
+
+    const before = await uploadedFilenames();
+    const res = await upload(ticketId, "one-too-many.png", "image/png");
+
+    expect(res.status).toBe(409);
+    expect(res.body.error.code).toBe("ATTACHMENT_LIMIT_REACHED");
+    expect(await prisma.attachment.count({ where: { ticketId } })).toBe(5);
+
+    // API-48: the rejected file reached disk before the count was checked, so
+    // it must have been cleaned up rather than left orphaned (BR-40).
+    expect(await uploadedFilenames()).toEqual(before);
+  });
+
+  it("API-44: allows a new upload once a removed attachment frees a slot", async () => {
+    const uploaded = [];
+    for (let i = 0; i < 5; i += 1) {
+      uploaded.push((await upload(ticketId, `file-${i}.png`, "image/png")).body);
+    }
+
+    expect((await upload(ticketId, "blocked.png", "image/png")).status).toBe(409);
+
+    const removal = await request(app)
+      .patch(`/api/attachments/${uploaded[0].id}/remove`)
+      .set("X-Requester-Id", String(ownerId))
+      .send({ removalReason: "Freeing a slot" });
+    expect(removal.status).toBe(200);
+
+    // Removed attachments do not count toward the limit (BR-31).
+    expect((await upload(ticketId, "now-allowed.png", "image/png")).status).toBe(201);
+  });
+
+  it("API-45: refuses an upload to a ticket owned by somebody else", async () => {
+    const before = await uploadedFilenames();
+
+    const res = await upload(strangerTicketId, "intrusion.png", "image/png");
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("TICKET_NOT_FOUND");
+    // Ownership is checked before the file is written, so nothing lands on disk.
+    expect(await uploadedFilenames()).toEqual(before);
+  });
+});
+
+describe("GET /api/attachments/:id — metadata", () => {
+  it("returns metadata for an attachment the caller owns", async () => {
+    const created = (await upload(ticketId, "evidence.pdf", "application/pdf")).body;
+
+    const res = await request(app)
+      .get(`/api/attachments/${created.id}`)
+      .set("X-Requester-Id", String(ownerId));
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      id: created.id,
+      originalFilename: "evidence.pdf",
+      mimeType: "application/pdf",
+      isRemoved: false,
+    });
+  });
+
+  it("API-56: refuses metadata for an attachment on another requester's ticket", async () => {
+    const created = (await upload(ticketId, "private.png", "image/png")).body;
+
+    const res = await request(app)
+      .get(`/api/attachments/${created.id}`)
+      .set("X-Requester-Id", String(strangerId));
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe("ATTACHMENT_NOT_FOUND");
+  });
+});
+
+describe("GET /api/attachments/:id/download", () => {
+  it("API-49: serves an active attachment with its original filename", async () => {
+    const created = (await upload(ticketId, "evidence.png", "image/png")).body;
+
+    const res = await request(app)
+      .get(`/api/attachments/${created.id}/download`)
+      .set("X-Requester-Id", String(ownerId));
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toContain("image/png");
+    expect(res.headers["content-disposition"]).toContain('filename="evidence.png"');
+    expect(res.headers["x-content-type-options"]).toBe("nosniff");
+    expect(Buffer.from(res.body).equals(PNG_BYTES)).toBe(true);
+  });
+
+  it("API-50: refuses to serve a removed attachment", async () => {
+    const created = (await upload(ticketId, "mistake.png", "image/png")).body;
+
+    await request(app)
+      .patch(`/api/attachments/${created.id}/remove`)
+      .set("X-Requester-Id", String(ownerId))
+      .send({ removalReason: "Uploaded the wrong screenshot" });
+
+    const res = await request(app)
+      .get(`/api/attachments/${created.id}/download`)
+      .set("X-Requester-Id", String(ownerId));
+
+    // 410 rather than 404: the caller owns it and already knows it exists from
+    // the ticket detail response, so a precise status leaks nothing and lets
+    // the client explain why (api-spec §3).
+    expect(res.status).toBe(410);
+    expect(res.body.error.code).toBe("ATTACHMENT_REMOVED");
+  });
+
+  it("API-51: refuses a download for another requester's attachment", async () => {
+    const created = (await upload(ticketId, "confidential.pdf", "application/pdf")).body;
+
+    const res = await request(app)
+      .get(`/api/attachments/${created.id}/download`)
+      .set("X-Requester-Id", String(strangerId));
+
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("PATCH /api/attachments/:id/remove — soft removal", () => {
+  it("API-52: records who removed it, when, and why, keeping the row", async () => {
+    const created = (await upload(ticketId, "wrong.png", "image/png")).body;
+
+    const res = await request(app)
+      .patch(`/api/attachments/${created.id}/remove`)
+      .set("X-Requester-Id", String(ownerId))
+      .send({ removalReason: "Uploaded the wrong screenshot" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.isRemoved).toBe(true);
+    expect(res.body.removalReason).toBe("Uploaded the wrong screenshot");
+
+    const saved = await prisma.attachment.findUniqueOrThrow({ where: { id: created.id } });
+    expect(saved.removedAt).not.toBeNull();
+    expect(saved.removedByRequesterId).toBe(ownerId);
+  });
+
+  it("API-57: leaves the stored file on disk, since removal revokes access rather than destroying data", async () => {
+    const created = (await upload(ticketId, "keep-bytes.png", "image/png")).body;
+    const saved = await prisma.attachment.findUniqueOrThrow({ where: { id: created.id } });
+
+    await request(app)
+      .patch(`/api/attachments/${created.id}/remove`)
+      .set("X-Requester-Id", String(ownerId))
+      .send({ removalReason: "No longer relevant" });
+
+    expect(fs.existsSync(storedFilePath(saved.storedFilename))).toBe(true);
+  });
+
+  it("API-53: requires a removal reason", async () => {
+    const created = (await upload(ticketId, "reasonless.png", "image/png")).body;
+
+    const res = await request(app)
+      .patch(`/api/attachments/${created.id}/remove`)
+      .set("X-Requester-Id", String(ownerId))
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.code).toBe("VALIDATION_FAILED");
+
+    const saved = await prisma.attachment.findUniqueOrThrow({ where: { id: created.id } });
+    expect(saved.removedAt).toBeNull();
+  });
+
+  it("API-54: rejects a reason shorter than the minimum", async () => {
+    const created = (await upload(ticketId, "short-reason.png", "image/png")).body;
+
+    const res = await request(app)
+      .patch(`/api/attachments/${created.id}/remove`)
+      .set("X-Requester-Id", String(ownerId))
+      .send({ removalReason: "no" });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("API-55: reports a second removal as a conflict rather than succeeding quietly", async () => {
+    const created = (await upload(ticketId, "double.png", "image/png")).body;
+    const remove = () =>
+      request(app)
+        .patch(`/api/attachments/${created.id}/remove`)
+        .set("X-Requester-Id", String(ownerId))
+        .send({ removalReason: "Removing this one" });
+
+    expect((await remove()).status).toBe(200);
+
+    // A silently idempotent 200 would hide a double submission (BR-35).
+    const second = await remove();
+    expect(second.status).toBe(409);
+    expect(second.body.error.code).toBe("ALREADY_REMOVED");
+  });
+
+  it("API-56: refuses removal by a requester who does not own the ticket", async () => {
+    const created = (await upload(ticketId, "not-yours.png", "image/png")).body;
+
+    const res = await request(app)
+      .patch(`/api/attachments/${created.id}/remove`)
+      .set("X-Requester-Id", String(strangerId))
+      .send({ removalReason: "Trying to remove someone else's file" });
+
+    expect(res.status).toBe(404);
+
+    const saved = await prisma.attachment.findUniqueOrThrow({ where: { id: created.id } });
+    expect(saved.removedAt).toBeNull();
+  });
+});
+
+describe("Attachment endpoints — requester identity", () => {
+  it("rejects a request with no identity header", async () => {
+    const res = await request(app).get("/api/attachments/1");
+
+    expect(res.status).toBe(401);
+    expect(res.body.error.code).toBe("REQUESTER_HEADER_MISSING");
+  });
+});


### PR DESCRIPTION
Add upload, metadata, download and soft removal. Stored filenames are generated UUIDs, so a requester filename containing a traversal sequence never reaches the path, and the upload directory is never served statically: every read passes the ownership check.

Ownership is verified before the upload middleware runs, so no file is written for a ticket the caller does not own, and the type filter rejects before the write, so a wrong type leaves nothing behind. That leaves the active-count check as the only path that can orphan a file, and it deletes the file before returning the conflict. Verified by removing the cleanup and watching the test fail with real files left in the directory.

Removal is soft: the row and the bytes both stay, only access is revoked, so a download of a removed attachment is 410 rather than 404. The caller owns it and already knows it exists from the ticket detail, so a precise status discloses nothing. Removing twice is a conflict rather than a quiet success, so a double submission stays visible.

The uploads directory is gitignored but keeps a committed .gitkeep, and is also created at boot, so a fresh clone does not fail on first upload.