### PR TITLE
Client foundation with routing, requester context and Zen G…

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "bootstrap": "^5.3.3",
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^7.18.3"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.6.3",
@@ -1884,6 +1885,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/css.escape": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
@@ -2751,6 +2765,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.3.tgz",
+      "integrity": "sha512-gyXgtdr5uACJ5b1Q4udzjVV+tb/rlHIMJKuJ0e89R4Kzgz47z/rgP0dIKxktqIEUhDHluGTPJJH/wRha7CyqsA==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.3.tgz",
+      "integrity": "sha512-ytVbyBBM7vMfRCam25r0WMhSVSom909A8p+8m0/f1w853dz/xfFu6etAT2SEbVoSnI+ZoPRDqIsQXVT89gp7kg==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.18.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -2856,6 +2908,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/siginfo": {
       "version": "2.0.0",

--- a/client/package.json
+++ b/client/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "bootstrap": "^5.3.3",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^7.18.3"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",

--- a/client/src/AppRouter.tsx
+++ b/client/src/AppRouter.tsx
@@ -1,0 +1,54 @@
+import { BrowserRouter, Navigate, Outlet, Route, Routes } from "react-router-dom";
+import App from "./App.js";
+import { AppShell } from "./components/AppShell.js";
+import { StateBlock } from "./components/StateBlock.js";
+import { RequesterProvider, useRequester } from "./context/RequesterContext.js";
+import { NotFoundPage } from "./pages/NotFoundPage.js";
+import { SelectRequesterPage } from "./pages/SelectRequesterPage.js";
+
+/**
+ * Sends the user to the selector when no requester is chosen (BR-46). It waits
+ * for hydration first, otherwise a reload would bounce a user who does have a
+ * stored selection back to the selector before it had been read.
+ */
+function RequireRequester() {
+  const { requester, hydrating } = useRequester();
+
+  if (hydrating) {
+    return <StateBlock kind="loading" title="Loading…" />;
+  }
+
+  return requester ? <Outlet /> : <Navigate to="/select-requester" replace />;
+}
+
+export function AppRoutes() {
+  return (
+    <Routes>
+      <Route path="/" element={<Navigate to="/tickets" replace />} />
+      <Route path="/select-requester" element={<SelectRequesterPage />} />
+
+      <Route element={<RequireRequester />}>
+        <Route element={<AppShell />}>
+          {/* Ticket screens arrive in Issues 13 to 15. */}
+          <Route path="/tickets" element={<div />} />
+          <Route path="/tickets/new" element={<div />} />
+          <Route path="/tickets/:id" element={<div />} />
+        </Route>
+      </Route>
+
+      {/* The Lab 1 system check, kept reachable and unchanged. */}
+      <Route path="/system-check" element={<App />} />
+      <Route path="*" element={<NotFoundPage />} />
+    </Routes>
+  );
+}
+
+export function AppRouter() {
+  return (
+    <BrowserRouter>
+      <RequesterProvider>
+        <AppRoutes />
+      </RequesterProvider>
+    </BrowserRouter>
+  );
+}

--- a/client/src/api/referenceData.ts
+++ b/client/src/api/referenceData.ts
@@ -1,0 +1,18 @@
+import { request } from "../lib/http.js";
+import type { DevRequester, ReferenceItem } from "../types/index.js";
+
+// Named exports on their own module, never re-exported through src/api.ts:
+// vi.spyOn cannot redefine an ESM re-exported binding, so a barrel would break
+// both these tests and the Lab 1 test that spies on api.ts.
+
+export function fetchCategories(): Promise<ReferenceItem[]> {
+  return request<ReferenceItem[]>("/api/categories");
+}
+
+export function fetchRelatedSystems(): Promise<ReferenceItem[]> {
+  return request<ReferenceItem[]>("/api/related-systems");
+}
+
+export function fetchDevRequesters(): Promise<DevRequester[]> {
+  return request<DevRequester[]>("/api/dev-requesters");
+}

--- a/client/src/components/AppShell.tsx
+++ b/client/src/components/AppShell.tsx
@@ -1,0 +1,66 @@
+import { NavLink, Outlet, useNavigate } from "react-router-dom";
+import { useRequester } from "../context/RequesterContext.js";
+
+export function AppShell() {
+  const { requester, clearRequester } = useRequester();
+  const navigate = useNavigate();
+
+  function changeRequester() {
+    // Clearing before navigating is what guarantees no data from the previous
+    // requester survives the switch (BR-08).
+    clearRequester();
+    navigate("/select-requester");
+  }
+
+  return (
+    <>
+      <header className="zen-header">
+        <nav className="navbar navbar-expand-md container zen-page" aria-label="Main">
+          <span className="navbar-brand fw-semibold">TokTickIT</span>
+
+          <button
+            className="navbar-toggler border-light"
+            type="button"
+            data-bs-toggle="collapse"
+            data-bs-target="#zen-nav"
+            aria-controls="zen-nav"
+            aria-expanded="false"
+            aria-label="Toggle navigation"
+          >
+            <span className="navbar-toggler-icon" />
+          </button>
+
+          <div className="collapse navbar-collapse" id="zen-nav">
+            <ul className="navbar-nav me-auto">
+              <li className="nav-item">
+                <NavLink className="nav-link" to="/tickets" end>
+                  My Tickets
+                </NavLink>
+              </li>
+              <li className="nav-item">
+                <NavLink className="nav-link" to="/tickets/new">
+                  Create Ticket
+                </NavLink>
+              </li>
+            </ul>
+
+            {requester && (
+              <div className="d-flex align-items-center gap-3 py-2 py-md-0">
+                <span className="text-white" data-testid="current-requester">
+                  {requester.fullName}
+                </span>
+                <button type="button" className="btn btn-sm btn-light" onClick={changeRequester}>
+                  Change Requester
+                </button>
+              </div>
+            )}
+          </div>
+        </nav>
+      </header>
+
+      <main className="container zen-page py-4">
+        <Outlet />
+      </main>
+    </>
+  );
+}

--- a/client/src/components/StateBlock.tsx
+++ b/client/src/components/StateBlock.tsx
@@ -1,0 +1,50 @@
+import type { ReactNode } from "react";
+
+type StateKind = "loading" | "empty" | "no-results" | "error";
+
+interface StateBlockProps {
+  kind: StateKind;
+  title: string;
+  description?: string;
+  /** Retry, Clear filters, Create ticket — whatever the state makes available. */
+  action?: ReactNode;
+}
+
+const ICONS: Record<StateKind, string> = {
+  loading: "⏳",
+  empty: "📄",
+  "no-results": "🔍",
+  error: "⚠️",
+};
+
+/**
+ * One component for the four states every asynchronous screen needs, so the
+ * empty and no-results cases cannot drift apart between screens.
+ *
+ * Empty and no-results are deliberately separate kinds: "you have no tickets"
+ * and "your filters matched nothing" call for different wording and different
+ * actions, and conflating them tells the requester something untrue (BR-42).
+ */
+export function StateBlock({ kind, title, description, action }: StateBlockProps) {
+  const isError = kind === "error";
+
+  return (
+    <div
+      className={`text-center py-5 px-3 ${isError ? "zen-error-panel" : ""}`}
+      role={isError ? "alert" : "status"}
+      aria-live={isError ? "assertive" : "polite"}
+      data-state={kind}
+    >
+      <div aria-hidden="true" style={{ fontSize: "2rem" }}>
+        {kind === "loading" ? (
+          <span className="spinner-border text-success" role="presentation" />
+        ) : (
+          ICONS[kind]
+        )}
+      </div>
+      <p className="fw-semibold mt-3 mb-1">{title}</p>
+      {description && <p className="zen-muted mb-3">{description}</p>}
+      {action}
+    </div>
+  );
+}

--- a/client/src/context/RequesterContext.tsx
+++ b/client/src/context/RequesterContext.tsx
@@ -1,0 +1,110 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import type { ReactNode } from "react";
+import { setRequesterId } from "../lib/http.js";
+import { fetchDevRequesters } from "../api/referenceData.js";
+import type { DevRequester } from "../types/index.js";
+
+const STORAGE_KEY = "toktickit.requesterId";
+
+interface RequesterContextValue {
+  requester: DevRequester | null;
+  /** False while the stored selection is being revalidated on first load. */
+  hydrating: boolean;
+  selectRequester: (requester: DevRequester) => void;
+  clearRequester: () => void;
+}
+
+const RequesterContext = createContext<RequesterContextValue | null>(null);
+
+function readStoredId(): number | null {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw === null ? null : Number(raw) || null;
+  } catch {
+    // Private browsing and blocked site data both throw here.
+    return null;
+  }
+}
+
+function writeStoredId(id: number | null): void {
+  try {
+    if (id === null) {
+      window.localStorage.removeItem(STORAGE_KEY);
+    } else {
+      window.localStorage.setItem(STORAGE_KEY, String(id));
+    }
+  } catch {
+    // Losing persistence is survivable; the selection still works this session.
+  }
+}
+
+export function RequesterProvider({ children }: { children: ReactNode }) {
+  const [requester, setRequester] = useState<DevRequester | null>(null);
+  const [hydrating, setHydrating] = useState(true);
+
+  // Persistence matters beyond convenience: the E2E run and the screenshot
+  // script both reload pages, and a selection that did not survive a reload
+  // would send them back to the selector every time.
+  useEffect(() => {
+    const storedId = readStoredId();
+    if (storedId === null) {
+      setHydrating(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    // Revalidated against the server rather than trusted: a requester
+    // deactivated between sessions must not stay selected (BR-07).
+    fetchDevRequesters()
+      .then((active) => {
+        if (cancelled) return;
+        const match = active.find((candidate) => candidate.id === storedId) ?? null;
+        if (match) {
+          setRequester(match);
+          setRequesterId(match.id);
+        } else {
+          writeStoredId(null);
+        }
+      })
+      .catch(() => {
+        // Leave the selection empty; the guard sends the user to the selector,
+        // which shows its own failure state.
+        if (!cancelled) writeStoredId(null);
+      })
+      .finally(() => {
+        if (!cancelled) setHydrating(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const selectRequester = useCallback((next: DevRequester) => {
+    setRequester(next);
+    setRequesterId(next.id);
+    writeStoredId(next.id);
+  }, []);
+
+  const clearRequester = useCallback(() => {
+    setRequester(null);
+    setRequesterId(null);
+    writeStoredId(null);
+  }, []);
+
+  const value = useMemo(
+    () => ({ requester, hydrating, selectRequester, clearRequester }),
+    [requester, hydrating, selectRequester, clearRequester]
+  );
+
+  return <RequesterContext.Provider value={value}>{children}</RequesterContext.Provider>;
+}
+
+export function useRequester(): RequesterContextValue {
+  const context = useContext(RequesterContext);
+  if (!context) {
+    throw new Error("useRequester must be used inside a RequesterProvider.");
+  }
+  return context;
+}

--- a/client/src/lib/http.ts
+++ b/client/src/lib/http.ts
@@ -1,0 +1,111 @@
+const API_URL = import.meta.env.VITE_API_URL ?? "http://localhost:3000";
+
+export interface FieldIssue {
+  field: string;
+  message: string;
+}
+
+/** A failed response, carrying enough detail for a screen to render field errors. */
+export class ApiError extends Error {
+  readonly status: number;
+  readonly code: string;
+  readonly details: FieldIssue[];
+
+  constructor(status: number, code: string, message: string, details: FieldIssue[] = []) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+    this.code = code;
+    this.details = details;
+  }
+
+  /** The message for one field, if the server reported one. */
+  fieldMessage(field: string): string | undefined {
+    return this.details.find((d) => d.field === field)?.message;
+  }
+}
+
+/**
+ * The selected requester id, held here rather than read from React context,
+ * because these functions are not components and cannot call hooks.
+ * RequesterProvider keeps it in step with the context.
+ *
+ * Lab 3 replaces this with an auth token and changes the header below; no
+ * screen or API function changes.
+ */
+let currentRequesterId: number | null = null;
+
+export function setRequesterId(id: number | null): void {
+  currentRequesterId = id;
+}
+
+export function getRequesterId(): number | null {
+  return currentRequesterId;
+}
+
+function requesterHeader(): Record<string, string> {
+  return currentRequesterId === null ? {} : { "X-Requester-Id": String(currentRequesterId) };
+}
+
+async function toApiError(response: Response): Promise<ApiError> {
+  try {
+    const body = await response.json();
+    const error = body?.error;
+    if (error?.code) {
+      return new ApiError(response.status, error.code, error.message, error.details ?? []);
+    }
+  } catch {
+    // A non-JSON error body is still a failure; fall through to the generic case.
+  }
+  return new ApiError(response.status, "UNEXPECTED", "Something went wrong. Please try again.");
+}
+
+/** Every JSON call goes through here, so the identity header is never forgotten. */
+export async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const response = await fetch(`${API_URL}${path}`, {
+    ...init,
+    headers: {
+      ...(init.body !== undefined && !(init.body instanceof FormData)
+        ? { "Content-Type": "application/json" }
+        : {}),
+      ...requesterHeader(),
+      ...init.headers,
+    },
+  });
+
+  if (!response.ok) {
+    throw await toApiError(response);
+  }
+
+  return response.status === 204 ? (undefined as T) : ((await response.json()) as T);
+}
+
+/**
+ * Downloads a file and hands it to the browser.
+ *
+ * A plain <a href> cannot do this: anchor navigation cannot set the
+ * X-Requester-Id header, and the API is on a different origin, so the request
+ * would fail the ownership check. Fetching to a blob is what lets the header
+ * travel. The filename comes from metadata the caller already holds, which
+ * avoids needing Content-Disposition exposed through CORS.
+ */
+export async function downloadFile(path: string, filename: string): Promise<void> {
+  const response = await fetch(`${API_URL}${path}`, { headers: requesterHeader() });
+
+  if (!response.ok) {
+    throw await toApiError(response);
+  }
+
+  const blobUrl = URL.createObjectURL(await response.blob());
+  try {
+    const anchor = document.createElement("a");
+    anchor.href = blobUrl;
+    anchor.download = filename;
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+  } finally {
+    // Without this the blob is retained for the lifetime of the page.
+    URL.revokeObjectURL(blobUrl);
+  }
+}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,10 +1,13 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import "bootstrap/dist/css/bootstrap.min.css";
-import App from "./App.js";
+// Must follow Bootstrap: the theme overrides component-level variables that
+// Bootstrap sets, so load order decides which wins.
+import "./theme.css";
+import { AppRouter } from "./AppRouter.js";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <App />
+    <AppRouter />
   </React.StrictMode>
 );

--- a/client/src/pages/NotFoundPage.tsx
+++ b/client/src/pages/NotFoundPage.tsx
@@ -1,0 +1,13 @@
+import { Link } from "react-router-dom";
+
+export function NotFoundPage() {
+  return (
+    <div className="text-center py-5">
+      <h1 className="h4">Page not found</h1>
+      <p className="zen-muted">The page you asked for does not exist.</p>
+      <Link className="btn btn-outline-primary" to="/tickets">
+        Back to My Tickets
+      </Link>
+    </div>
+  );
+}

--- a/client/src/pages/SelectRequesterPage.tsx
+++ b/client/src/pages/SelectRequesterPage.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { fetchDevRequesters } from "../api/referenceData.js";
+import { useRequester } from "../context/RequesterContext.js";
+import { StateBlock } from "../components/StateBlock.js";
+import type { DevRequester } from "../types/index.js";
+
+type LoadState = "loading" | "ready" | "error";
+
+export function SelectRequesterPage() {
+  const [state, setState] = useState<LoadState>("loading");
+  const [requesters, setRequesters] = useState<DevRequester[]>([]);
+  const [selectedId, setSelectedId] = useState("");
+  const { selectRequester } = useRequester();
+  const navigate = useNavigate();
+
+  function load() {
+    setState("loading");
+    fetchDevRequesters()
+      .then((list) => {
+        setRequesters(list);
+        setState("ready");
+      })
+      .catch(() => setState("error"));
+  }
+
+  useEffect(load, []);
+
+  function handleContinue() {
+    const chosen = requesters.find((r) => String(r.id) === selectedId);
+    if (!chosen) return;
+    selectRequester(chosen);
+    navigate("/tickets");
+  }
+
+  return (
+    <main className="container zen-page py-5">
+      <div className="mx-auto zen-card p-4" style={{ maxWidth: 560 }}>
+        <h1 className="h4 text-center mb-1">TokTickIT</h1>
+        <h2 className="h5 text-center mb-2">Select Development Requester</h2>
+        <p className="text-center zen-muted mb-4">
+          Select a Development Requester to test requester-specific ticket behavior. This is not a
+          login screen. Authentication and role-based access will be introduced in Lab 3.
+        </p>
+
+        {state === "loading" && <StateBlock kind="loading" title="Loading development requesters…" />}
+
+        {state === "error" && (
+          <StateBlock
+            kind="error"
+            title="Could not load development requesters"
+            description="The service did not respond. Check that the API is running and try again."
+            action={
+              <button type="button" className="btn btn-outline-primary" onClick={load}>
+                Retry
+              </button>
+            }
+          />
+        )}
+
+        {state === "ready" && requesters.length === 0 && (
+          <StateBlock
+            kind="empty"
+            title="No active development requesters found"
+            description="Run the database seed to create them, then reload this page."
+          />
+        )}
+
+        {state === "ready" && requesters.length > 0 && (
+          <>
+            <div className="mb-3">
+              <label className="form-label fw-semibold" htmlFor="requester-select">
+                Development Requester
+                <span className="zen-required" aria-hidden="true">
+                  *
+                </span>
+                <span className="visually-hidden">(required)</span>
+              </label>
+              <select
+                id="requester-select"
+                className="form-select"
+                value={selectedId}
+                onChange={(event) => setSelectedId(event.target.value)}
+              >
+                <option value="">Choose a requester…</option>
+                {requesters.map((requester) => (
+                  <option key={requester.id} value={requester.id}>
+                    {requester.fullName}
+                    {requester.department ? ` — ${requester.department}` : ""}
+                  </option>
+                ))}
+              </select>
+              <p className="zen-muted mt-2 mb-0" style={{ fontSize: "0.875rem" }}>
+                Only active development requesters are shown.
+              </p>
+            </div>
+
+            <div className="zen-success mb-4">
+              <p className="fw-semibold mb-1">Authentication coming in Lab 3</p>
+              <p className="mb-0" style={{ fontSize: "0.9rem" }}>
+                In Lab 3 this selection will be replaced with secure authentication so you can
+                access the system with your own account.
+              </p>
+            </div>
+
+            <div className="d-flex justify-content-end gap-2">
+              <button
+                type="button"
+                className="btn btn-primary"
+                disabled={selectedId === ""}
+                onClick={handleContinue}
+              >
+                Continue
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/client/src/theme.css
+++ b/client/src/theme.css
@@ -1,0 +1,230 @@
+/*
+ * Zen Green theme. Imported after bootstrap.min.css in main.tsx.
+ *
+ * Bootstrap 5.3 is loaded precompiled, and it bakes per-variant colours into
+ * each component class at Sass compile time. Overriding --bs-primary alone
+ * therefore does NOT recolour .btn-primary — the component-level variables
+ * below have to be set explicitly. This was verified rather than assumed.
+ */
+
+:root {
+  --zen-primary: #006b3c;
+  --zen-secondary: #0b7a46;
+  --zen-pale: #eaf6ef;
+  --zen-bg: #f5f7f6;
+  --zen-surface: #ffffff;
+  --zen-border: #dde5e0;
+  --zen-text: #1b2b23;
+  --zen-text-muted: #5a6b62;
+  --zen-readonly-bg: #f2f4f1;
+  --zen-error: #a4161a;
+  --zen-warning: #b26a00;
+  --zen-success: #0b7a46;
+
+  --bs-body-bg: var(--zen-bg);
+  --bs-body-color: var(--zen-text);
+  --bs-link-color: var(--zen-secondary);
+  --bs-link-hover-color: var(--zen-primary);
+  --bs-border-color: var(--zen-border);
+}
+
+body {
+  background-color: var(--zen-bg);
+  color: var(--zen-text);
+}
+
+/* --- Application shell --------------------------------------------------- */
+
+.zen-header {
+  background-color: var(--zen-primary);
+  color: #fff;
+}
+
+.zen-header .navbar-brand,
+.zen-header .nav-link {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.zen-header .nav-link:hover,
+.zen-header .nav-link:focus {
+  color: #fff;
+}
+
+/* The active page is marked by weight and an underline as well as colour, so
+   the indication does not depend on colour perception alone. */
+.zen-header .nav-link.active {
+  color: #fff;
+  font-weight: 600;
+  border-bottom: 3px solid #fff;
+}
+
+/* --- Buttons ------------------------------------------------------------- */
+
+.btn-primary {
+  --bs-btn-bg: var(--zen-primary);
+  --bs-btn-border-color: var(--zen-primary);
+  --bs-btn-hover-bg: var(--zen-secondary);
+  --bs-btn-hover-border-color: var(--zen-secondary);
+  --bs-btn-active-bg: var(--zen-secondary);
+  --bs-btn-active-border-color: var(--zen-secondary);
+  --bs-btn-disabled-bg: var(--zen-primary);
+  --bs-btn-disabled-border-color: var(--zen-primary);
+}
+
+.btn-outline-primary {
+  --bs-btn-color: var(--zen-primary);
+  --bs-btn-border-color: var(--zen-primary);
+  --bs-btn-hover-bg: var(--zen-primary);
+  --bs-btn-hover-border-color: var(--zen-primary);
+  --bs-btn-active-bg: var(--zen-primary);
+  --bs-btn-active-border-color: var(--zen-primary);
+}
+
+.btn-outline-danger {
+  --bs-btn-color: var(--zen-error);
+  --bs-btn-border-color: var(--zen-error);
+  --bs-btn-hover-bg: var(--zen-error);
+  --bs-btn-hover-border-color: var(--zen-error);
+}
+
+.btn-link {
+  --bs-btn-color: var(--zen-secondary);
+  --bs-btn-hover-color: var(--zen-primary);
+}
+
+/* --- Surfaces ------------------------------------------------------------ */
+
+.zen-card {
+  background-color: var(--zen-surface);
+  border: 1px solid var(--zen-border);
+  border-radius: 0.5rem;
+  box-shadow: 0 1px 2px rgba(27, 43, 35, 0.06);
+}
+
+/* --- Form controls ------------------------------------------------------- */
+
+.form-control:focus,
+.form-select:focus {
+  border-color: var(--zen-secondary);
+  box-shadow: 0 0 0 0.2rem rgba(11, 122, 70, 0.2);
+}
+
+/* Read-only fields: clearly distinct from an editable field, still readable. */
+.zen-readonly {
+  background-color: var(--zen-readonly-bg);
+  border: 1px solid var(--zen-border);
+  border-radius: 0.375rem;
+  padding: 0.375rem 0.75rem;
+  min-height: 38px;
+  color: var(--zen-text);
+}
+
+.zen-required {
+  color: var(--zen-error);
+  margin-left: 0.15rem;
+}
+
+/* Validation messages sit directly below their field, never only at the top. */
+.zen-field-error {
+  color: var(--zen-error);
+  font-size: 0.875rem;
+  margin-top: 0.25rem;
+}
+
+.form-control.is-invalid,
+.form-select.is-invalid {
+  border-color: var(--zen-error);
+}
+
+/* Focus must stay visible for keyboard users at every breakpoint. */
+:focus-visible {
+  outline: 2px solid var(--zen-secondary);
+  outline-offset: 2px;
+}
+
+/* --- Feedback ------------------------------------------------------------ */
+
+/* Success carries a glyph and text as well as the pale green ground, so it
+   never relies on colour alone. */
+.zen-success {
+  background-color: var(--zen-pale);
+  border: 1px solid var(--zen-secondary);
+  color: var(--zen-text);
+  border-radius: 0.5rem;
+  padding: 1rem;
+}
+
+.zen-error-panel {
+  background-color: #fdf3f3;
+  border: 1px solid var(--zen-error);
+  color: var(--zen-text);
+  border-radius: 0.5rem;
+  padding: 1rem;
+}
+
+.zen-warning-panel {
+  background-color: #fdf6ea;
+  border: 1px solid var(--zen-warning);
+  color: var(--zen-text);
+  border-radius: 0.5rem;
+  padding: 1rem;
+}
+
+.zen-muted {
+  color: var(--zen-text-muted);
+}
+
+/* --- Badges -------------------------------------------------------------- */
+
+/* Identical geometry across screens, and always paired with their text label. */
+.zen-badge {
+  display: inline-block;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  border: 1px solid transparent;
+}
+
+.zen-badge-low {
+  background-color: #eef1ef;
+  color: var(--zen-text-muted);
+  border-color: var(--zen-border);
+}
+
+.zen-badge-medium {
+  background-color: var(--zen-pale);
+  color: var(--zen-secondary);
+  border-color: var(--zen-secondary);
+}
+
+.zen-badge-high {
+  background-color: #fdf6ea;
+  color: var(--zen-warning);
+  border-color: var(--zen-warning);
+}
+
+.zen-badge-urgent {
+  background-color: #fdf3f3;
+  color: var(--zen-error);
+  border-color: var(--zen-error);
+}
+
+.zen-badge-status {
+  background-color: var(--zen-pale);
+  color: var(--zen-secondary);
+  border-color: var(--zen-secondary);
+}
+
+/* --- Layout -------------------------------------------------------------- */
+
+.zen-page {
+  max-width: 1140px;
+}
+
+/* Touch targets stay comfortable on small screens. */
+@media (max-width: 767.98px) {
+  .btn {
+    min-height: 44px;
+  }
+}

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -1,0 +1,60 @@
+export type Priority = "LOW" | "MEDIUM" | "HIGH" | "URGENT";
+export type TicketStatus = "NEW";
+
+export interface ReferenceItem {
+  id: number;
+  name: string;
+}
+
+export interface DevRequester {
+  id: number;
+  fullName: string;
+  email: string;
+  department: string | null;
+}
+
+export interface AttachmentMeta {
+  id: number;
+  originalFilename: string;
+  mimeType: string;
+  sizeBytes: number;
+  uploadedAt: string;
+  isRemoved: boolean;
+  removedAt: string | null;
+  removalReason: string | null;
+}
+
+export interface TicketListItem {
+  id: number;
+  ticketNumber: string;
+  summary: string;
+  requestedPriority: Priority;
+  currentStatus: TicketStatus;
+  createdAt: string;
+  category: ReferenceItem;
+  relatedSystem: ReferenceItem;
+  attachmentCount: number;
+}
+
+export interface TicketDetail {
+  id: number;
+  ticketNumber: string;
+  summary: string;
+  description: string;
+  requestedPriority: Priority;
+  currentStatus: TicketStatus;
+  createdAt: string;
+  updatedAt: string;
+  category: ReferenceItem;
+  relatedSystem: ReferenceItem;
+  requester: DevRequester;
+  attachments: AttachmentMeta[];
+}
+
+export interface PagedResult<T> {
+  data: T[];
+  page: number;
+  pageSize: number;
+  total: number;
+  totalPages: number;
+}

--- a/client/tests/lab-02/AppShell.test.tsx
+++ b/client/tests/lab-02/AppShell.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { AppShell } from "../../src/components/AppShell.js";
+import { RequesterProvider } from "../../src/context/RequesterContext.js";
+import { AppRoutes } from "../../src/AppRouter.js";
+import * as referenceData from "../../src/api/referenceData.js";
+import { getRequesterId } from "../../src/lib/http.js";
+import type { DevRequester } from "../../src/types/index.js";
+
+const REQUESTERS: DevRequester[] = [
+  { id: 1, fullName: "Jennifer Anderson", email: "jennifer@kmutt.ac.th", department: "Engineering" },
+  { id: 2, fullName: "Michael Brown", email: "michael@kmutt.ac.th", department: "Registrar" },
+];
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("Application shell", () => {
+  it("UI-25: shows the selected requester's name", async () => {
+    vi.spyOn(referenceData, "fetchDevRequesters").mockResolvedValue(REQUESTERS);
+    window.localStorage.setItem("toktickit.requesterId", "1");
+
+    render(
+      <MemoryRouter initialEntries={["/tickets"]}>
+        <RequesterProvider>
+          <Routes>
+            <Route element={<AppShell />}>
+              <Route path="/tickets" element={<p>Ticket list</p>} />
+            </Route>
+          </Routes>
+        </RequesterProvider>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByTestId("current-requester")).toHaveTextContent("Jennifer Anderson");
+  });
+
+  it("UI-25: Change Requester clears the selection and returns to the selector", async () => {
+    vi.spyOn(referenceData, "fetchDevRequesters").mockResolvedValue(REQUESTERS);
+    window.localStorage.setItem("toktickit.requesterId", "1");
+
+    render(
+      <MemoryRouter initialEntries={["/tickets"]}>
+        <RequesterProvider>
+          <AppRoutes />
+        </RequesterProvider>
+      </MemoryRouter>
+    );
+
+    await screen.findByTestId("current-requester");
+    fireEvent.click(screen.getByRole("button", { name: /Change Requester/i }));
+
+    // Landing back on the selector is what guarantees the previous requester's
+    // data cannot still be on screen (BR-08).
+    expect(await screen.findByRole("heading", { name: /Select Development Requester/i })).toBeInTheDocument();
+    expect(screen.queryByTestId("current-requester")).not.toBeInTheDocument();
+    expect(window.localStorage.getItem("toktickit.requesterId")).toBeNull();
+    expect(getRequesterId()).toBeNull();
+  });
+});
+
+describe("Requester guard and persistence", () => {
+  it("UI-18: redirects to the selector when no requester is selected", async () => {
+    vi.spyOn(referenceData, "fetchDevRequesters").mockResolvedValue(REQUESTERS);
+
+    render(
+      <MemoryRouter initialEntries={["/tickets"]}>
+        <RequesterProvider>
+          <AppRoutes />
+        </RequesterProvider>
+      </MemoryRouter>
+    );
+
+    expect(
+      await screen.findByRole("heading", { name: /Select Development Requester/i })
+    ).toBeInTheDocument();
+  });
+
+  it("restores a stored selection, so a reload does not send the user back to the selector", async () => {
+    vi.spyOn(referenceData, "fetchDevRequesters").mockResolvedValue(REQUESTERS);
+    window.localStorage.setItem("toktickit.requesterId", "2");
+
+    render(
+      <MemoryRouter initialEntries={["/tickets"]}>
+        <RequesterProvider>
+          <AppRoutes />
+        </RequesterProvider>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByTestId("current-requester")).toHaveTextContent("Michael Brown");
+    // The identity the API layer will send must match the restored selection.
+    expect(getRequesterId()).toBe(2);
+  });
+
+  it("discards a stored selection that is no longer active", async () => {
+    // Requester 9 is not in the active list the server returns, so it must not
+    // stay selected across sessions (BR-07).
+    vi.spyOn(referenceData, "fetchDevRequesters").mockResolvedValue(REQUESTERS);
+    window.localStorage.setItem("toktickit.requesterId", "9");
+
+    render(
+      <MemoryRouter initialEntries={["/tickets"]}>
+        <RequesterProvider>
+          <AppRoutes />
+        </RequesterProvider>
+      </MemoryRouter>
+    );
+
+    expect(
+      await screen.findByRole("heading", { name: /Select Development Requester/i })
+    ).toBeInTheDocument();
+    expect(window.localStorage.getItem("toktickit.requesterId")).toBeNull();
+  });
+});

--- a/client/tests/lab-02/SelectRequester.test.tsx
+++ b/client/tests/lab-02/SelectRequester.test.tsx
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { RequesterProvider } from "../../src/context/RequesterContext.js";
+import { SelectRequesterPage } from "../../src/pages/SelectRequesterPage.js";
+// Spied on directly rather than through a barrel: vi.spyOn cannot redefine an
+// ESM re-exported binding, so re-exporting these through src/api.ts would
+// break both this test and the Lab 1 test.
+import * as referenceData from "../../src/api/referenceData.js";
+import type { DevRequester } from "../../src/types/index.js";
+
+const ACTIVE: DevRequester[] = [
+  { id: 1, fullName: "Jennifer Anderson", email: "jennifer@kmutt.ac.th", department: "Engineering" },
+  { id: 2, fullName: "Michael Brown", email: "michael@kmutt.ac.th", department: "Registrar" },
+  { id: 3, fullName: "Sarah Johnson", email: "sarah@kmutt.ac.th", department: "Science" },
+  { id: 4, fullName: "David Lee", email: "david@kmutt.ac.th", department: "Library" },
+];
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/select-requester"]}>
+      <RequesterProvider>
+        <Routes>
+          <Route path="/select-requester" element={<SelectRequesterPage />} />
+          <Route path="/tickets" element={<h1>My Tickets</h1>} />
+        </Routes>
+      </RequesterProvider>
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("Development Requester Selection", () => {
+  it("UI-01: lists the active requesters returned by the server", async () => {
+    vi.spyOn(referenceData, "fetchDevRequesters").mockResolvedValue(ACTIVE);
+
+    renderPage();
+
+    expect(await screen.findByRole("option", { name: /Jennifer Anderson/ })).toBeInTheDocument();
+    for (const requester of ACTIVE) {
+      expect(screen.getByRole("option", { name: new RegExp(requester.fullName) })).toBeInTheDocument();
+    }
+  });
+
+  it("UI-01: shows no requester the server did not return", async () => {
+    // The server excludes inactive requesters, so the screen simply renders
+    // what it is given — the exclusion is not re-implemented in the client,
+    // where it could be bypassed (BR-06).
+    vi.spyOn(referenceData, "fetchDevRequesters").mockResolvedValue(ACTIVE);
+
+    renderPage();
+
+    await screen.findByRole("option", { name: /Jennifer Anderson/ });
+    expect(screen.queryByRole("option", { name: /Somsri Inactive/ })).not.toBeInTheDocument();
+  });
+
+  it("states that this is not a login screen", async () => {
+    vi.spyOn(referenceData, "fetchDevRequesters").mockResolvedValue(ACTIVE);
+
+    renderPage();
+
+    expect(await screen.findByText(/not a login screen/i)).toBeInTheDocument();
+    expect(screen.getByText(/Authentication coming in Lab 3/i)).toBeInTheDocument();
+  });
+
+  it("keeps Continue disabled until a requester is chosen", async () => {
+    vi.spyOn(referenceData, "fetchDevRequesters").mockResolvedValue(ACTIVE);
+
+    renderPage();
+
+    const button = await screen.findByRole("button", { name: /Continue/i });
+    expect(button).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText(/Development Requester/i), { target: { value: "2" } });
+    expect(button).toBeEnabled();
+  });
+
+  it("selects the requester and moves on to My Tickets", async () => {
+    vi.spyOn(referenceData, "fetchDevRequesters").mockResolvedValue(ACTIVE);
+
+    renderPage();
+
+    fireEvent.change(await screen.findByLabelText(/Development Requester/i), {
+      target: { value: "2" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Continue/i }));
+
+    expect(await screen.findByRole("heading", { name: "My Tickets" })).toBeInTheDocument();
+  });
+
+  it("UI-02: shows an empty state when no active requesters exist", async () => {
+    vi.spyOn(referenceData, "fetchDevRequesters").mockResolvedValue([]);
+
+    renderPage();
+
+    expect(await screen.findByText(/No active development requesters found/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Continue/i })).not.toBeInTheDocument();
+  });
+
+  it("UI-02: shows a safe failure state with a retry action", async () => {
+    const spy = vi
+      .spyOn(referenceData, "fetchDevRequesters")
+      .mockRejectedValue(new Error("Network down"));
+
+    renderPage();
+
+    expect(await screen.findByText(/Could not load development requesters/i)).toBeInTheDocument();
+    // The internal error text must not reach the requester (BR-27).
+    expect(screen.queryByText(/Network down/)).not.toBeInTheDocument();
+
+    spy.mockResolvedValue(ACTIVE);
+    fireEvent.click(screen.getByRole("button", { name: /Retry/i }));
+
+    expect(await screen.findByRole("option", { name: /Jennifer Anderson/ })).toBeInTheDocument();
+  });
+
+  it("shows a loading state while the request is in flight", async () => {
+    let resolve: (value: DevRequester[]) => void = () => {};
+    vi.spyOn(referenceData, "fetchDevRequesters").mockReturnValue(
+      new Promise<DevRequester[]>((r) => {
+        resolve = r;
+      })
+    );
+
+    renderPage();
+
+    expect(screen.getByText(/Loading development requesters/i)).toBeInTheDocument();
+
+    resolve(ACTIVE);
+    await waitFor(() => expect(screen.queryByText(/Loading development requesters/i)).not.toBeInTheDocument());
+  });
+
+  it("marks the required field with an asterisk that does not replace the label", async () => {
+    vi.spyOn(referenceData, "fetchDevRequesters").mockResolvedValue(ACTIVE);
+
+    renderPage();
+
+    await screen.findByLabelText(/Development Requester/i);
+    // The asterisk is decorative; the accessible name carries "(required)".
+    expect(screen.getByText("*")).toHaveAttribute("aria-hidden", "true");
+    expect(screen.getByText("(required)")).toBeInTheDocument();
+  });
+});

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -8,6 +8,9 @@
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
+    // `npm run build` runs tsc purely as a type check and lets Vite do the
+    // bundling. Without this, tsc also emits .js files beside every source.
+    "noEmit": true,
     "types": ["vitest/globals", "@testing-library/jest-dom"]
   },
   "include": ["src", "tests"]

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -8,6 +8,12 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     setupFiles: "./tests/setup.ts",
-    include: ["tests/**/*.test.tsx"],
+    // Was .test.tsx only, which silently skipped any .test.ts file — it would
+    // report as passing while never having run.
+    include: ["tests/**/*.test.{ts,tsx}"],
+    // Suites spy on API modules with vi.spyOn. Without this the spies leak
+    // between tests and produce order-dependent failures that look like
+    // component bugs.
+    restoreMocks: true,
   },
 });

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -131,8 +131,8 @@ File: `server/tests/lab-02/attachments.api.test.ts`
 
 | Test ID | Type | Requirement / AC | What it tests | Expected result | Automated test file | Final |
 |---|---|---|---|---|---|---|
-| UI-01 | UI | AC-01, BR-06 | Selector lists active requesters only | Four active names rendered; the inactive one absent | `client/tests/lab-02/SelectRequester.test.tsx` | Planned |
-| UI-02 | UI | AC-06, BR-09 | Selector empty and failure states | Empty message with Continue disabled; failure message with Retry | `client/tests/lab-02/SelectRequester.test.tsx` | Planned |
+| UI-01 | UI | AC-01, BR-06 | Selector lists active requesters only | Four active names rendered; the inactive one absent | `client/tests/lab-02/SelectRequester.test.tsx` | Pass |
+| UI-02 | UI | AC-06, BR-09 | Selector empty and failure states | Empty message with Continue disabled; failure message with Retry | `client/tests/lab-02/SelectRequester.test.tsx` | Pass |
 | UI-03 | UI | AC-11 | Submit with an empty Summary | Message rendered below the Summary field; the API is not called | `client/tests/lab-02/CreateTicket.test.tsx` | Planned |
 | UI-04 | UI | AC-14, BR-25 | Busy state on submit | Submit disabled with a busy label; a second click creates nothing | `client/tests/lab-02/CreateTicket.test.tsx` | Planned |
 | UI-05 | UI | AC-07 | Success state | The returned ticket number is displayed with confirming text, not colour alone | `client/tests/lab-02/CreateTicket.test.tsx` | Planned |
@@ -148,14 +148,14 @@ File: `server/tests/lab-02/attachments.api.test.ts`
 | UI-15 | UI style | ui-spec §5 | Badge consistency | Priority and status badges render text alongside colour | `client/tests/lab-02/MyTickets.test.tsx` | Planned |
 | UI-16 | UI | AC-29 | Detail renders read-only | Every specified field present and read-only | `client/tests/lab-02/RequesterTicketDetail.test.tsx` | Planned |
 | UI-17 | UI | AC-30, BR-45 | Out-of-scope features absent | No comments, internal notes, actions taken, IT priority, or status control | `client/tests/lab-02/RequesterTicketDetail.test.tsx` | Planned |
-| UI-18 | UI | AC-02, BR-46 | Guard without a selected requester | Redirects to the selection screen | `client/tests/lab-02/RequesterTicketDetail.test.tsx` | Planned |
+| UI-18 | UI | AC-02, BR-46 | Guard without a selected requester | Redirects to the selection screen | `client/tests/lab-02/RequesterTicketDetail.test.tsx` | Pass |
 | UI-19 | UI | BR-43 | No attachments | Explicit message rather than an empty region | `client/tests/lab-02/AttachmentSection.test.tsx` | Planned |
 | UI-20 | UI | AC-32 | Upload happy path | Selected file uploads and appears in the list | `client/tests/lab-02/AttachmentSection.test.tsx` | Planned |
 | UI-21 | UI | BR-29, BR-30 | Client-side pre-checks | Oversized and wrong-type files are rejected before any request | `client/tests/lab-02/AttachmentSection.test.tsx` | Planned |
 | UI-22 | UI | BR-31 | Limit reached | Upload control disabled with an explanation at 5 active | `client/tests/lab-02/AttachmentSection.test.tsx` | Planned |
 | UI-23 | UI | BR-33, ui-spec §7.4 | Removed attachment presentation | Greyed, reason shown, **no download and no remove action** | `client/tests/lab-02/AttachmentSection.test.tsx` | Planned |
 | UI-24 | UI | BR-34 | Removal dialog | Confirm disabled until a valid reason is entered | `client/tests/lab-02/AttachmentSection.test.tsx` | Planned |
-| UI-25 | UI | AC-03, AC-04, BR-08 | Shell and requester switching | Name displayed; switching clears the previous Requester's data | `client/tests/lab-02/AppShell.test.tsx` | Planned |
+| UI-25 | UI | AC-03, AC-04, BR-08 | Shell and requester switching | Name displayed; switching clears the previous Requester's data | `client/tests/lab-02/AppShell.test.tsx` | Pass |
 
 ### 2.7 End-to-end and responsive
 


### PR DESCRIPTION
…reen theme

Add react-router, the selected-requester context, the shared HTTP layer and the Zen Green theme, plus the Development Requester Selection screen.

App.tsx and api.ts are untouched. The Lab 1 screen is reachable at /system-check and its tests still pass unchanged. New API functions live in their own modules rather than being re-exported through api.ts, because vi.spyOn cannot redefine an ESM re-exported binding and a barrel would break those tests.

The requester id is held in the HTTP layer and kept in step by the provider, so screens never pass it explicitly and Lab 3 changes one header in one file. A stored selection is revalidated against the server on load rather than trusted, since a requester deactivated between sessions must not stay selected, and the route guard waits for that check so a reload does not bounce a signed-in user back to the selector.

Bootstrap is loaded precompiled and bakes button colours in at compile time, so overriding --bs-primary alone would not have recoloured anything. The theme sets the component-level variables explicitly; verified in the built CSS that those rules follow Bootstrap's own and win the cascade.

Also fixes a pre-existing config bug: the build script runs tsc as a type check and lets Vite bundle, but tsconfig lacked noEmit, so building wrote sixteen .js files beside the sources.