### PR TITLE
Create Ticket screen

### DIFF
--- a/client/src/AppRouter.tsx
+++ b/client/src/AppRouter.tsx
@@ -3,6 +3,7 @@ import App from "./App.js";
 import { AppShell } from "./components/AppShell.js";
 import { StateBlock } from "./components/StateBlock.js";
 import { RequesterProvider, useRequester } from "./context/RequesterContext.js";
+import { CreateTicketPage } from "./pages/CreateTicketPage.js";
 import { NotFoundPage } from "./pages/NotFoundPage.js";
 import { SelectRequesterPage } from "./pages/SelectRequesterPage.js";
 
@@ -29,9 +30,9 @@ export function AppRoutes() {
 
       <Route element={<RequireRequester />}>
         <Route element={<AppShell />}>
-          {/* Ticket screens arrive in Issues 13 to 15. */}
+          {/* The list and detail screens arrive in Issues 14 and 15. */}
           <Route path="/tickets" element={<div />} />
-          <Route path="/tickets/new" element={<div />} />
+          <Route path="/tickets/new" element={<CreateTicketPage />} />
           <Route path="/tickets/:id" element={<div />} />
         </Route>
       </Route>

--- a/client/src/api/tickets.ts
+++ b/client/src/api/tickets.ts
@@ -1,0 +1,21 @@
+import { request } from "../lib/http.js";
+import type { Priority, TicketDetail } from "../types/index.js";
+
+// Named exports on their own module so tests can spy on them directly; never
+// re-exported through src/api.ts (vi.spyOn cannot redefine a re-exported
+// ESM binding).
+
+export interface CreateTicketPayload {
+  categoryId: number;
+  relatedSystemId: number;
+  requestedPriority: Priority;
+  summary: string;
+  description: string;
+}
+
+export function createTicket(payload: CreateTicketPayload): Promise<TicketDetail> {
+  return request<TicketDetail>("/api/tickets", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+}

--- a/client/src/components/FormField.tsx
+++ b/client/src/components/FormField.tsx
@@ -1,0 +1,54 @@
+import type { ReactNode } from "react";
+
+interface FormFieldProps {
+  id: string;
+  label: string;
+  required?: boolean;
+  error?: string;
+  hint?: string;
+  children: (props: { id: string; describedBy?: string; invalid: boolean }) => ReactNode;
+}
+
+/**
+ * Keeps the label, the required marker and the validation message together, so
+ * a message can never end up far from the field it describes.
+ *
+ * The asterisk is decorative and paired with a visually hidden "(required)",
+ * because an asterisk alone is not an accessible name — and it never replaces
+ * the validation message either (ui-spec §3).
+ */
+export function FormField({ id, label, required, error, hint, children }: FormFieldProps) {
+  const errorId = `${id}-error`;
+  const hintId = `${id}-hint`;
+  const describedBy = [error ? errorId : null, hint ? hintId : null].filter(Boolean).join(" ");
+
+  return (
+    <div className="mb-3">
+      <label className="form-label fw-semibold" htmlFor={id}>
+        {label}
+        {required && (
+          <>
+            <span className="zen-required" aria-hidden="true">
+              *
+            </span>
+            <span className="visually-hidden">(required)</span>
+          </>
+        )}
+      </label>
+
+      {children({ id, describedBy: describedBy || undefined, invalid: Boolean(error) })}
+
+      {hint && (
+        <p id={hintId} className="zen-muted mb-0" style={{ fontSize: "0.875rem" }}>
+          {hint}
+        </p>
+      )}
+
+      {error && (
+        <p id={errorId} className="zen-field-error mb-0" role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/client/src/pages/CreateTicketPage.tsx
+++ b/client/src/pages/CreateTicketPage.tsx
@@ -1,0 +1,359 @@
+import { useEffect, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { fetchCategories, fetchRelatedSystems } from "../api/referenceData.js";
+import { createTicket } from "../api/tickets.js";
+import { FormField } from "../components/FormField.js";
+import { StateBlock } from "../components/StateBlock.js";
+import { ApiError } from "../lib/http.js";
+import { useRequester } from "../context/RequesterContext.js";
+import type { Priority, ReferenceItem, TicketDetail } from "../types/index.js";
+
+const PRIORITIES: Priority[] = ["LOW", "MEDIUM", "HIGH", "URGENT"];
+
+interface FormValues {
+  categoryId: string;
+  relatedSystemId: string;
+  requestedPriority: Priority | "";
+  summary: string;
+  description: string;
+}
+
+const EMPTY: FormValues = {
+  categoryId: "",
+  relatedSystemId: "",
+  requestedPriority: "",
+  summary: "",
+  description: "",
+};
+
+/**
+ * Mirrors the server rules so the requester gets feedback without a round
+ * trip. It is not the gate — the server validates everything again (BR-24).
+ */
+function validate(values: FormValues): Record<string, string> {
+  const errors: Record<string, string> = {};
+
+  if (!values.categoryId) errors.categoryId = "Select a category.";
+  if (!values.relatedSystemId) errors.relatedSystemId = "Select a related system.";
+  if (!values.requestedPriority) errors.requestedPriority = "Select a requested priority.";
+
+  const summary = values.summary.trim();
+  if (summary.length === 0) errors.summary = "Summary is required.";
+  else if (summary.length < 5) errors.summary = "Summary must be at least 5 characters.";
+  else if (summary.length > 200) errors.summary = "Summary must be at most 200 characters.";
+
+  const description = values.description.trim();
+  if (description.length === 0) errors.description = "Description is required.";
+  else if (description.length < 10) errors.description = "Description must be at least 10 characters.";
+  else if (description.length > 5000) errors.description = "Description must be at most 5000 characters.";
+
+  return errors;
+}
+
+export function CreateTicketPage() {
+  const { requester } = useRequester();
+  const navigate = useNavigate();
+
+  const [categories, setCategories] = useState<ReferenceItem[]>([]);
+  const [relatedSystems, setRelatedSystems] = useState<ReferenceItem[]>([]);
+  const [referenceState, setReferenceState] = useState<"loading" | "ready" | "error">("loading");
+
+  const [values, setValues] = useState<FormValues>(EMPTY);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [created, setCreated] = useState<TicketDetail | null>(null);
+
+  function loadReferenceData() {
+    setReferenceState("loading");
+    Promise.all([fetchCategories(), fetchRelatedSystems()])
+      .then(([loadedCategories, loadedSystems]) => {
+        setCategories(loadedCategories);
+        setRelatedSystems(loadedSystems);
+        setReferenceState("ready");
+      })
+      .catch(() => setReferenceState("error"));
+  }
+
+  useEffect(loadReferenceData, []);
+
+  function update<K extends keyof FormValues>(field: K, value: FormValues[K]) {
+    setValues((previous) => ({ ...previous, [field]: value }));
+  }
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+
+    const found = validate(values);
+    setErrors(found);
+    setSubmitError(null);
+    if (Object.keys(found).length > 0) {
+      // No request is sent when the form is already known to be invalid.
+      document.getElementById(Object.keys(found)[0])?.focus();
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const ticket = await createTicket({
+        categoryId: Number(values.categoryId),
+        relatedSystemId: Number(values.relatedSystemId),
+        requestedPriority: values.requestedPriority as Priority,
+        summary: values.summary.trim(),
+        description: values.description.trim(),
+      });
+      setCreated(ticket);
+    } catch (error) {
+      // Values are deliberately not cleared: a failure must leave everything
+      // the requester typed available to retry (BR-26).
+      if (error instanceof ApiError && error.details.length > 0) {
+        setErrors(Object.fromEntries(error.details.map((d) => [d.field, d.message])));
+        setSubmitError("Please correct the highlighted fields and try again.");
+      } else {
+        setSubmitError(
+          error instanceof ApiError
+            ? error.message
+            : "The ticket could not be submitted. Check your connection and try again."
+        );
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function createAnother() {
+    setCreated(null);
+    setValues(EMPTY);
+    setErrors({});
+    setSubmitError(null);
+  }
+
+  if (created) {
+    return (
+      <div className="zen-success" role="status">
+        <p className="fw-semibold mb-1">
+          {/* Meaning is carried by the glyph and the text, not by colour alone. */}
+          <span aria-hidden="true">✓ </span>
+          Ticket {created.ticketNumber} created successfully
+        </p>
+        <p className="mb-3">Your request has been submitted and is now awaiting IT support.</p>
+        <div className="d-flex flex-wrap gap-2">
+          <Link className="btn btn-primary" to={`/tickets/${created.id}`}>
+            View ticket
+          </Link>
+          <button type="button" className="btn btn-outline-primary" onClick={createAnother}>
+            Create another ticket
+          </button>
+          <button type="button" className="btn btn-link" onClick={() => navigate("/tickets")}>
+            Back to My Tickets
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <h1 className="h3 mb-1">Create Ticket</h1>
+      <p className="zen-muted mb-4">Describe your problem so IT support can help you.</p>
+
+      {referenceState === "loading" && <StateBlock kind="loading" title="Loading form options…" />}
+
+      {referenceState === "error" && (
+        <StateBlock
+          kind="error"
+          title="Could not load the form options"
+          description="Categories and related systems are unavailable. Try again in a moment."
+          action={
+            <button type="button" className="btn btn-outline-primary" onClick={loadReferenceData}>
+              Retry
+            </button>
+          }
+        />
+      )}
+
+      {referenceState === "ready" && (
+        <form onSubmit={handleSubmit} noValidate>
+          {/* System-generated values, visually distinct from editable fields. */}
+          <section className="zen-card p-3 p-md-4 mb-4">
+            <h2 className="h6 mb-3">Ticket information</h2>
+            <div className="row">
+              <div className="col-12 col-md-4 mb-3">
+                <span className="form-label fw-semibold d-block">Ticket No.</span>
+                <div className="zen-readonly" data-testid="readonly-ticket-number">
+                  Will be generated on submit
+                </div>
+              </div>
+              <div className="col-12 col-md-4 mb-3">
+                <span className="form-label fw-semibold d-block">Ticket Date</span>
+                <div className="zen-readonly">{new Date().toLocaleDateString()}</div>
+              </div>
+              <div className="col-12 col-md-4 mb-3">
+                <span className="form-label fw-semibold d-block">Requester</span>
+                <div className="zen-readonly" data-testid="readonly-requester">
+                  {requester?.fullName ?? ""}
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section className="zen-card p-3 p-md-4 mb-4">
+            <h2 className="h6 mb-3">Classification</h2>
+            <div className="row">
+              <div className="col-12 col-md-6 col-lg-4">
+                <FormField id="categoryId" label="Category" required error={errors.categoryId}>
+                  {({ id, describedBy, invalid }) => (
+                    <select
+                      id={id}
+                      className={`form-select ${invalid ? "is-invalid" : ""}`}
+                      aria-describedby={describedBy}
+                      aria-invalid={invalid}
+                      value={values.categoryId}
+                      onChange={(e) => update("categoryId", e.target.value)}
+                    >
+                      <option value="">Select a category…</option>
+                      {categories.map((category) => (
+                        <option key={category.id} value={category.id}>
+                          {category.name}
+                        </option>
+                      ))}
+                    </select>
+                  )}
+                </FormField>
+              </div>
+
+              <div className="col-12 col-md-6 col-lg-4">
+                <FormField
+                  id="relatedSystemId"
+                  label="Related System"
+                  required
+                  error={errors.relatedSystemId}
+                >
+                  {({ id, describedBy, invalid }) => (
+                    <select
+                      id={id}
+                      className={`form-select ${invalid ? "is-invalid" : ""}`}
+                      aria-describedby={describedBy}
+                      aria-invalid={invalid}
+                      value={values.relatedSystemId}
+                      onChange={(e) => update("relatedSystemId", e.target.value)}
+                    >
+                      <option value="">Select a related system…</option>
+                      {relatedSystems.map((system) => (
+                        <option key={system.id} value={system.id}>
+                          {system.name}
+                        </option>
+                      ))}
+                    </select>
+                  )}
+                </FormField>
+              </div>
+
+              <div className="col-12 col-md-6 col-lg-4">
+                <FormField
+                  id="requestedPriority"
+                  label="Requested Priority"
+                  required
+                  error={errors.requestedPriority}
+                >
+                  {({ id, describedBy, invalid }) => (
+                    <select
+                      id={id}
+                      className={`form-select ${invalid ? "is-invalid" : ""}`}
+                      aria-describedby={describedBy}
+                      aria-invalid={invalid}
+                      value={values.requestedPriority}
+                      onChange={(e) => update("requestedPriority", e.target.value as Priority)}
+                    >
+                      <option value="">Select a priority…</option>
+                      {PRIORITIES.map((priority) => (
+                        <option key={priority} value={priority}>
+                          {priority.charAt(0) + priority.slice(1).toLowerCase()}
+                        </option>
+                      ))}
+                    </select>
+                  )}
+                </FormField>
+              </div>
+            </div>
+          </section>
+
+          <section className="zen-card p-3 p-md-4 mb-4">
+            <h2 className="h6 mb-3">Problem details</h2>
+
+            <FormField
+              id="summary"
+              label="Ticket Summary"
+              required
+              error={errors.summary}
+              hint="A short headline, 5 to 200 characters."
+            >
+              {({ id, describedBy, invalid }) => (
+                <input
+                  id={id}
+                  type="text"
+                  className={`form-control ${invalid ? "is-invalid" : ""}`}
+                  aria-describedby={describedBy}
+                  aria-invalid={invalid}
+                  maxLength={200}
+                  value={values.summary}
+                  onChange={(e) => update("summary", e.target.value)}
+                />
+              )}
+            </FormField>
+
+            <FormField
+              id="description"
+              label="Description"
+              required
+              error={errors.description}
+              hint="Explain what happened, when it started, and what you have already tried."
+            >
+              {({ id, describedBy, invalid }) => (
+                <textarea
+                  id={id}
+                  rows={6}
+                  className={`form-control ${invalid ? "is-invalid" : ""}`}
+                  aria-describedby={describedBy}
+                  aria-invalid={invalid}
+                  maxLength={5000}
+                  value={values.description}
+                  onChange={(e) => update("description", e.target.value)}
+                />
+              )}
+            </FormField>
+          </section>
+
+          {submitError && (
+            <div className="zen-error-panel mb-3" role="alert">
+              {submitError}
+            </div>
+          )}
+
+          <div className="d-flex flex-column flex-md-row justify-content-md-end gap-2">
+            <button
+              type="button"
+              className="btn btn-outline-primary order-md-1"
+              onClick={() => navigate("/tickets")}
+              disabled={submitting}
+            >
+              Cancel
+            </button>
+            {/* Disabled while in flight, so a second click cannot create a
+                second ticket (BR-25). */}
+            <button type="submit" className="btn btn-primary order-md-2" disabled={submitting}>
+              {submitting ? (
+                <>
+                  <span className="spinner-border spinner-border-sm me-2" aria-hidden="true" />
+                  Submitting…
+                </>
+              ) : (
+                "Submit Ticket"
+              )}
+            </button>
+          </div>
+        </form>
+      )}
+    </>
+  );
+}

--- a/client/tests/lab-02/CreateTicket.test.tsx
+++ b/client/tests/lab-02/CreateTicket.test.tsx
@@ -1,0 +1,301 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { CreateTicketPage } from "../../src/pages/CreateTicketPage.js";
+import { RequesterProvider } from "../../src/context/RequesterContext.js";
+import * as referenceData from "../../src/api/referenceData.js";
+import * as ticketsApi from "../../src/api/tickets.js";
+import { ApiError } from "../../src/lib/http.js";
+import type { DevRequester, TicketDetail } from "../../src/types/index.js";
+
+const REQUESTER: DevRequester = {
+  id: 1,
+  fullName: "Jennifer Anderson",
+  email: "jennifer@kmutt.ac.th",
+  department: "Engineering",
+};
+
+const CATEGORIES = [
+  { id: 1, name: "Account and Access" },
+  { id: 2, name: "Hardware" },
+];
+const SYSTEMS = [
+  { id: 1, name: "Email" },
+  { id: 8, name: "Corporate Laptop" },
+];
+
+const CREATED: TicketDetail = {
+  id: 42,
+  ticketNumber: "TKT-2026-000042",
+  summary: "Laptop battery drains quickly",
+  description: "The battery drains much faster than usual even when the system is idle.",
+  requestedPriority: "MEDIUM",
+  currentStatus: "NEW",
+  createdAt: "2026-09-04T09:14:00.000Z",
+  updatedAt: "2026-09-04T09:14:00.000Z",
+  category: CATEGORIES[1],
+  relatedSystem: SYSTEMS[1],
+  requester: REQUESTER,
+  attachments: [],
+};
+
+function renderPage() {
+  window.localStorage.setItem("toktickit.requesterId", "1");
+  return render(
+    <MemoryRouter initialEntries={["/tickets/new"]}>
+      <RequesterProvider>
+        <Routes>
+          <Route path="/tickets/new" element={<CreateTicketPage />} />
+          <Route path="/tickets" element={<h1>My Tickets</h1>} />
+          <Route path="/tickets/:id" element={<h1>Ticket detail</h1>} />
+        </Routes>
+      </RequesterProvider>
+    </MemoryRouter>
+  );
+}
+
+/** Fills every field with data that passes client-side validation. */
+async function fillValidForm() {
+  fireEvent.change(await screen.findByLabelText(/Category/i), { target: { value: "2" } });
+  fireEvent.change(screen.getByLabelText(/Related System/i), { target: { value: "8" } });
+  fireEvent.change(screen.getByLabelText(/Requested Priority/i), { target: { value: "MEDIUM" } });
+  fireEvent.change(screen.getByLabelText(/Ticket Summary/i), {
+    target: { value: "Laptop battery drains quickly" },
+  });
+  fireEvent.change(screen.getByLabelText(/Description/i), {
+    target: { value: "The battery drains much faster than usual even when idle." },
+  });
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+  vi.spyOn(referenceData, "fetchDevRequesters").mockResolvedValue([REQUESTER]);
+  vi.spyOn(referenceData, "fetchCategories").mockResolvedValue(CATEGORIES);
+  vi.spyOn(referenceData, "fetchRelatedSystems").mockResolvedValue(SYSTEMS);
+});
+
+describe("Create Ticket — initial state", () => {
+  it("loads reference data from the server into the selects", async () => {
+    renderPage();
+
+    expect(await screen.findByRole("option", { name: "Hardware" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Corporate Laptop" })).toBeInTheDocument();
+  });
+
+  it("UI-09: shows system-generated values as read-only, populated from the selected requester", async () => {
+    renderPage();
+
+    const requesterField = await screen.findByTestId("readonly-requester");
+    expect(requesterField).toHaveTextContent("Jennifer Anderson");
+    expect(requesterField).toHaveClass("zen-readonly");
+
+    const ticketNumberField = screen.getByTestId("readonly-ticket-number");
+    expect(ticketNumberField).toHaveTextContent(/generated on submit/i);
+    expect(ticketNumberField).toHaveClass("zen-readonly");
+  });
+
+  it("UI-08: marks every required field with an asterisk that does not replace its label", async () => {
+    renderPage();
+
+    await screen.findByLabelText(/Category/i);
+    // Five required fields, each carrying a decorative asterisk plus an
+    // accessible "(required)".
+    expect(screen.getAllByText("*")).toHaveLength(5);
+    expect(screen.getAllByText("(required)")).toHaveLength(5);
+  });
+});
+
+describe("Create Ticket — validation", () => {
+  it("UI-03: shows a message below Summary and sends no request when it is empty", async () => {
+    const createSpy = vi.spyOn(ticketsApi, "createTicket");
+    renderPage();
+
+    await screen.findByLabelText(/Category/i);
+    fireEvent.click(screen.getByRole("button", { name: /Submit Ticket/i }));
+
+    expect(await screen.findByText("Summary is required.")).toBeInTheDocument();
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it("UI-03: rejects a summary shorter than the minimum without calling the API", async () => {
+    const createSpy = vi.spyOn(ticketsApi, "createTicket");
+    renderPage();
+
+    await fillValidForm();
+    fireEvent.change(screen.getByLabelText(/Ticket Summary/i), { target: { value: "help" } });
+    fireEvent.click(screen.getByRole("button", { name: /Submit Ticket/i }));
+
+    expect(await screen.findByText(/at least 5 characters/i)).toBeInTheDocument();
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  it("UI-07: wires each message to its field with aria-describedby and aria-invalid", async () => {
+    renderPage();
+
+    await screen.findByLabelText(/Category/i);
+    fireEvent.click(screen.getByRole("button", { name: /Submit Ticket/i }));
+
+    const summary = await screen.findByLabelText(/Ticket Summary/i);
+    expect(summary).toHaveAttribute("aria-invalid", "true");
+
+    const describedBy = summary.getAttribute("aria-describedby");
+    expect(describedBy).toContain("summary-error");
+    // The message is reachable from the field, not floating at the top of the
+    // form on its own (BR-28).
+    expect(document.getElementById("summary-error")).toHaveTextContent("Summary is required.");
+  });
+
+  it("clears a field's message once the value becomes valid and is resubmitted", async () => {
+    vi.spyOn(ticketsApi, "createTicket").mockResolvedValue(CREATED);
+    renderPage();
+
+    await screen.findByLabelText(/Category/i);
+    fireEvent.click(screen.getByRole("button", { name: /Submit Ticket/i }));
+    expect(await screen.findByText("Summary is required.")).toBeInTheDocument();
+
+    await fillValidForm();
+    fireEvent.click(screen.getByRole("button", { name: /Submit Ticket/i }));
+
+    await waitFor(() => expect(screen.queryByText("Summary is required.")).not.toBeInTheDocument());
+  });
+});
+
+describe("Create Ticket — submission", () => {
+  it("UI-05: shows the ticket number returned by the server", async () => {
+    vi.spyOn(ticketsApi, "createTicket").mockResolvedValue(CREATED);
+    renderPage();
+
+    await fillValidForm();
+    fireEvent.click(screen.getByRole("button", { name: /Submit Ticket/i }));
+
+    const success = await screen.findByText(/TKT-2026-000042 created successfully/i);
+    expect(success).toBeInTheDocument();
+    // Success is conveyed by text, not colour alone (AC-48).
+    expect(screen.getByRole("link", { name: /View ticket/i })).toBeInTheDocument();
+  });
+
+  it("sends exactly the values entered, trimmed", async () => {
+    const createSpy = vi.spyOn(ticketsApi, "createTicket").mockResolvedValue(CREATED);
+    renderPage();
+
+    await fillValidForm();
+    fireEvent.change(screen.getByLabelText(/Ticket Summary/i), {
+      target: { value: "  Laptop battery drains quickly  " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Submit Ticket/i }));
+
+    await waitFor(() => expect(createSpy).toHaveBeenCalledTimes(1));
+    expect(createSpy).toHaveBeenCalledWith({
+      categoryId: 2,
+      relatedSystemId: 8,
+      requestedPriority: "MEDIUM",
+      summary: "Laptop battery drains quickly",
+      description: "The battery drains much faster than usual even when idle.",
+    });
+  });
+
+  it("UI-04: disables submit and shows a busy state while the request is in flight", async () => {
+    let resolve: (value: TicketDetail) => void = () => {};
+    const createSpy = vi.spyOn(ticketsApi, "createTicket").mockReturnValue(
+      new Promise<TicketDetail>((r) => {
+        resolve = r;
+      })
+    );
+    renderPage();
+
+    await fillValidForm();
+    const submit = screen.getByRole("button", { name: /Submit Ticket/i });
+    fireEvent.click(submit);
+
+    const busy = await screen.findByRole("button", { name: /Submitting/i });
+    expect(busy).toBeDisabled();
+
+    // A second click while busy must not produce a second ticket (BR-25).
+    fireEvent.click(busy);
+    expect(createSpy).toHaveBeenCalledTimes(1);
+
+    resolve(CREATED);
+    await screen.findByText(/created successfully/i);
+  });
+});
+
+describe("Create Ticket — failure handling", () => {
+  it("UI-06: keeps every entered value when the API fails", async () => {
+    vi.spyOn(ticketsApi, "createTicket").mockRejectedValue(new Error("Network down"));
+    renderPage();
+
+    await fillValidForm();
+    fireEvent.click(screen.getByRole("button", { name: /Submit Ticket/i }));
+
+    expect(await screen.findByText(/could not be submitted/i)).toBeInTheDocument();
+    // Nothing the requester typed is lost (BR-26).
+    expect(screen.getByLabelText(/Ticket Summary/i)).toHaveValue("Laptop battery drains quickly");
+    expect(screen.getByLabelText(/Category/i)).toHaveValue("2");
+    expect(screen.getByLabelText(/Description/i)).toHaveValue(
+      "The battery drains much faster than usual even when idle."
+    );
+  });
+
+  it("UI-06: never shows the internal error text to the requester", async () => {
+    vi.spyOn(ticketsApi, "createTicket").mockRejectedValue(
+      new Error("ECONNREFUSED 127.0.0.1:3000")
+    );
+    renderPage();
+
+    await fillValidForm();
+    fireEvent.click(screen.getByRole("button", { name: /Submit Ticket/i }));
+
+    await screen.findByText(/could not be submitted/i);
+    expect(screen.queryByText(/ECONNREFUSED/)).not.toBeInTheDocument();
+  });
+
+  it("re-enables submit after a failure so the requester can retry", async () => {
+    const spy = vi
+      .spyOn(ticketsApi, "createTicket")
+      .mockRejectedValueOnce(new Error("Network down"))
+      .mockResolvedValueOnce(CREATED);
+    renderPage();
+
+    await fillValidForm();
+    fireEvent.click(screen.getByRole("button", { name: /Submit Ticket/i }));
+    await screen.findByText(/could not be submitted/i);
+
+    const submit = screen.getByRole("button", { name: /Submit Ticket/i });
+    expect(submit).toBeEnabled();
+
+    fireEvent.click(submit);
+    expect(await screen.findByText(/created successfully/i)).toBeInTheDocument();
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it("renders server field errors beside the fields they name", async () => {
+    vi.spyOn(ticketsApi, "createTicket").mockRejectedValue(
+      new ApiError(400, "VALIDATION_FAILED", "The submitted data is invalid.", [
+        { field: "summary", message: "Summary must be at least 5 characters." },
+        { field: "categoryId", message: "Select a valid category." },
+      ])
+    );
+    renderPage();
+
+    await fillValidForm();
+    fireEvent.click(screen.getByRole("button", { name: /Submit Ticket/i }));
+
+    expect(await screen.findByText("Summary must be at least 5 characters.")).toBeInTheDocument();
+    expect(screen.getByText("Select a valid category.")).toBeInTheDocument();
+    expect(screen.getByLabelText(/Ticket Summary/i)).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("shows a retryable failure state when the reference data cannot load", async () => {
+    const spy = vi
+      .spyOn(referenceData, "fetchCategories")
+      .mockRejectedValue(new Error("Service unavailable"));
+    renderPage();
+
+    expect(await screen.findByText(/Could not load the form options/i)).toBeInTheDocument();
+
+    spy.mockResolvedValue(CATEGORIES);
+    fireEvent.click(screen.getByRole("button", { name: /Retry/i }));
+
+    expect(await screen.findByRole("option", { name: "Hardware" })).toBeInTheDocument();
+  });
+});

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -133,13 +133,13 @@ File: `server/tests/lab-02/attachments.api.test.ts`
 |---|---|---|---|---|---|---|
 | UI-01 | UI | AC-01, BR-06 | Selector lists active requesters only | Four active names rendered; the inactive one absent | `client/tests/lab-02/SelectRequester.test.tsx` | Pass |
 | UI-02 | UI | AC-06, BR-09 | Selector empty and failure states | Empty message with Continue disabled; failure message with Retry | `client/tests/lab-02/SelectRequester.test.tsx` | Pass |
-| UI-03 | UI | AC-11 | Submit with an empty Summary | Message rendered below the Summary field; the API is not called | `client/tests/lab-02/CreateTicket.test.tsx` | Planned |
-| UI-04 | UI | AC-14, BR-25 | Busy state on submit | Submit disabled with a busy label; a second click creates nothing | `client/tests/lab-02/CreateTicket.test.tsx` | Planned |
-| UI-05 | UI | AC-07 | Success state | The returned ticket number is displayed with confirming text, not colour alone | `client/tests/lab-02/CreateTicket.test.tsx` | Planned |
-| UI-06 | UI | AC-13, AC-15, BR-26 | Values preserved after failure | Every entered value still present after an API error | `client/tests/lab-02/CreateTicket.test.tsx` | Planned |
-| UI-07 | UI style | BR-28, ui-spec §3 | Validation placement and ARIA | Message follows its field; `aria-invalid` and `aria-describedby` set | `client/tests/lab-02/CreateTicket.test.tsx` | Planned |
-| UI-08 | UI style | ui-spec §3 | Required asterisk | Every required label carries an asterisk, and it does not replace the message | `client/tests/lab-02/CreateTicket.test.tsx` | Planned |
-| UI-09 | UI style | ui-spec §3 | Read-only field styling | Read-only fields carry the read-only class and the `readonly` attribute | `client/tests/lab-02/CreateTicket.test.tsx` | Planned |
+| UI-03 | UI | AC-11 | Submit with an empty Summary | Message rendered below the Summary field; the API is not called | `client/tests/lab-02/CreateTicket.test.tsx` | Pass |
+| UI-04 | UI | AC-14, BR-25 | Busy state on submit | Submit disabled with a busy label; a second click creates nothing | `client/tests/lab-02/CreateTicket.test.tsx` | Pass |
+| UI-05 | UI | AC-07 | Success state | The returned ticket number is displayed with confirming text, not colour alone | `client/tests/lab-02/CreateTicket.test.tsx` | Pass |
+| UI-06 | UI | AC-13, AC-15, BR-26 | Values preserved after failure | Every entered value still present after an API error | `client/tests/lab-02/CreateTicket.test.tsx` | Pass |
+| UI-07 | UI style | BR-28, ui-spec §3 | Validation placement and ARIA | Message follows its field; `aria-invalid` and `aria-describedby` set | `client/tests/lab-02/CreateTicket.test.tsx` | Pass |
+| UI-08 | UI style | ui-spec §3 | Required asterisk | Every required label carries an asterisk, and it does not replace the message | `client/tests/lab-02/CreateTicket.test.tsx` | Pass |
+| UI-09 | UI style | ui-spec §3 | Read-only field styling | Read-only fields carry the read-only class and the `readonly` attribute | `client/tests/lab-02/CreateTicket.test.tsx` | Pass |
 | UI-10 | UI | AC-25, BR-41 | Empty state | Invites creating a first ticket | `client/tests/lab-02/MyTickets.test.tsx` | Planned |
 | UI-11 | UI | AC-26, BR-42 | No-results state | Distinct wording plus a Clear Filters action | `client/tests/lab-02/MyTickets.test.tsx` | Planned |
 | UI-12 | UI | AC-27, FR-26 | List failure state | Safe message plus Retry | `client/tests/lab-02/MyTickets.test.tsx` | Planned |


### PR DESCRIPTION
Add the Create Ticket form: read-only system-generated values, grouped classification fields, Summary and Description, and the success state showing the ticket number the backend returned.

FormField takes its input as a render prop and hands back the id, the describedBy and the invalid flag, so every field is wired to its own message through aria-describedby and no message can drift away from the field it describes. The required asterisk is decorative and paired with a visually hidden "(required)", since an asterisk alone is not an accessible name and must not stand in for the validation message.

Client validation mirrors the server rules to give faster feedback, but the server remains the gate. A failed submission keeps every entered value so the requester can retry, and server field errors are rendered beside the fields they name rather than collected at the top.

Submit is disabled while a request is in flight, so a second click cannot create a second ticket. Verified by removing the guard and watching the test fail.