### PR TITLE
My Tickets screen with search, filters, sorting and pagination

### DIFF
--- a/client/src/AppRouter.tsx
+++ b/client/src/AppRouter.tsx
@@ -4,6 +4,7 @@ import { AppShell } from "./components/AppShell.js";
 import { StateBlock } from "./components/StateBlock.js";
 import { RequesterProvider, useRequester } from "./context/RequesterContext.js";
 import { CreateTicketPage } from "./pages/CreateTicketPage.js";
+import { MyTicketsPage } from "./pages/MyTicketsPage.js";
 import { NotFoundPage } from "./pages/NotFoundPage.js";
 import { SelectRequesterPage } from "./pages/SelectRequesterPage.js";
 
@@ -30,8 +31,8 @@ export function AppRoutes() {
 
       <Route element={<RequireRequester />}>
         <Route element={<AppShell />}>
-          {/* The list and detail screens arrive in Issues 14 and 15. */}
-          <Route path="/tickets" element={<div />} />
+          {/* The detail screen arrives in Issue 15. */}
+          <Route path="/tickets" element={<MyTicketsPage />} />
           <Route path="/tickets/new" element={<CreateTicketPage />} />
           <Route path="/tickets/:id" element={<div />} />
         </Route>

--- a/client/src/api/tickets.ts
+++ b/client/src/api/tickets.ts
@@ -1,5 +1,5 @@
 import { request } from "../lib/http.js";
-import type { Priority, TicketDetail } from "../types/index.js";
+import type { PagedResult, Priority, TicketDetail, TicketListItem } from "../types/index.js";
 
 // Named exports on their own module so tests can spy on them directly; never
 // re-exported through src/api.ts (vi.spyOn cannot redefine a re-exported
@@ -18,4 +18,29 @@ export function createTicket(payload: CreateTicketPayload): Promise<TicketDetail
     method: "POST",
     body: JSON.stringify(payload),
   });
+}
+
+export type TicketSortField = "createdAt" | "ticketNumber" | "requestedPriority" | "summary";
+
+export interface TicketQuery {
+  page: number;
+  pageSize: number;
+  q?: string;
+  categoryId?: number;
+  relatedSystemId?: number;
+  priority?: Priority;
+  sort: TicketSortField;
+  order: "asc" | "desc";
+}
+
+export function fetchMyTickets(query: TicketQuery): Promise<PagedResult<TicketListItem>> {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(query)) {
+    // Empty values are omitted rather than sent blank: the server rejects
+    // malformed parameters instead of ignoring them.
+    if (value !== undefined && value !== "") {
+      params.set(key, String(value));
+    }
+  }
+  return request<PagedResult<TicketListItem>>(`/api/tickets?${params.toString()}`);
 }

--- a/client/src/components/Badges.tsx
+++ b/client/src/components/Badges.tsx
@@ -1,0 +1,33 @@
+import type { Priority, TicketStatus } from "../types/index.js";
+
+const PRIORITY_CLASS: Record<Priority, string> = {
+  LOW: "zen-badge-low",
+  MEDIUM: "zen-badge-medium",
+  HIGH: "zen-badge-high",
+  URGENT: "zen-badge-urgent",
+};
+
+function titleCase(value: string): string {
+  return value.charAt(0) + value.slice(1).toLowerCase();
+}
+
+/**
+ * Both badges always render their label. Colour carries emphasis, never the
+ * meaning on its own, so the value stays legible to anyone who cannot
+ * distinguish the ramp (ui-spec §5).
+ */
+export function PriorityBadge({ priority }: { priority: Priority }) {
+  return (
+    <span className={`zen-badge ${PRIORITY_CLASS[priority]}`} data-testid="priority-badge">
+      {titleCase(priority)}
+    </span>
+  );
+}
+
+export function StatusBadge({ status }: { status: TicketStatus }) {
+  return (
+    <span className="zen-badge zen-badge-status" data-testid="status-badge">
+      {titleCase(status)}
+    </span>
+  );
+}

--- a/client/src/components/Pagination.tsx
+++ b/client/src/components/Pagination.tsx
@@ -1,0 +1,61 @@
+interface PaginationProps {
+  page: number;
+  pageSize: number;
+  total: number;
+  totalPages: number;
+  onPageChange: (page: number) => void;
+}
+
+export function Pagination({ page, pageSize, total, totalPages, onPageChange }: PaginationProps) {
+  const first = total === 0 ? 0 : (page - 1) * pageSize + 1;
+  const last = Math.min(page * pageSize, total);
+
+  return (
+    <div className="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2 mt-3">
+      <p className="zen-muted mb-0" data-testid="pagination-summary">
+        Showing {first} to {last} of {total} tickets
+      </p>
+
+      <nav aria-label="Ticket list pages">
+        <ul className="pagination mb-0">
+          <li className={`page-item ${page <= 1 ? "disabled" : ""}`}>
+            <button
+              type="button"
+              className="page-link"
+              onClick={() => onPageChange(page - 1)}
+              disabled={page <= 1}
+            >
+              Previous
+            </button>
+          </li>
+
+          {Array.from({ length: totalPages }, (_, index) => index + 1).map((number) => (
+            <li key={number} className={`page-item ${number === page ? "active" : ""}`}>
+              <button
+                type="button"
+                className="page-link"
+                // Marked for assistive technology as well as visually, so the
+                // current page is not signalled by styling alone.
+                aria-current={number === page ? "page" : undefined}
+                onClick={() => onPageChange(number)}
+              >
+                {number}
+              </button>
+            </li>
+          ))}
+
+          <li className={`page-item ${page >= totalPages ? "disabled" : ""}`}>
+            <button
+              type="button"
+              className="page-link"
+              onClick={() => onPageChange(page + 1)}
+              disabled={page >= totalPages}
+            >
+              Next
+            </button>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  );
+}

--- a/client/src/components/TicketList.tsx
+++ b/client/src/components/TicketList.tsx
@@ -1,0 +1,114 @@
+import { Link } from "react-router-dom";
+import { PriorityBadge, StatusBadge } from "./Badges.js";
+import type { TicketListItem } from "../types/index.js";
+import type { TicketSortField } from "../api/tickets.js";
+
+interface TicketListProps {
+  tickets: TicketListItem[];
+  sort: TicketSortField;
+  order: "asc" | "desc";
+  onSortChange: (field: TicketSortField) => void;
+}
+
+const SORTABLE: { field: TicketSortField; label: string }[] = [
+  { field: "ticketNumber", label: "Ticket No." },
+  { field: "createdAt", label: "Created Date" },
+  { field: "summary", label: "Summary" },
+];
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+/**
+ * Renders a table from md upward and stacked cards below it.
+ *
+ * Cards rather than a horizontally scrolling table: the sprint forbids
+ * horizontal page scrolling on mobile, and a card keeps every field readable
+ * instead of clipping the row (D-07).
+ */
+export function TicketList({ tickets, sort, order, onSortChange }: TicketListProps) {
+  function ariaSort(field: TicketSortField): "ascending" | "descending" | "none" {
+    if (sort !== field) return "none";
+    return order === "asc" ? "ascending" : "descending";
+  }
+
+  return (
+    <>
+      {/* Desktop and tablet */}
+      <div className="d-none d-md-block zen-card">
+        <table className="table table-hover align-middle mb-0">
+          <thead>
+            <tr>
+              {SORTABLE.map(({ field, label }) => (
+                <th key={field} scope="col" aria-sort={ariaSort(field)}>
+                  <button
+                    type="button"
+                    className="btn btn-link p-0 text-decoration-none fw-semibold"
+                    onClick={() => onSortChange(field)}
+                  >
+                    {label}
+                    <span aria-hidden="true">
+                      {sort === field ? (order === "asc" ? " ▲" : " ▼") : " ⇅"}
+                    </span>
+                  </button>
+                </th>
+              ))}
+              <th scope="col">Category</th>
+              <th scope="col">Related System</th>
+              <th scope="col">Requested Priority</th>
+              <th scope="col">Current Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {tickets.map((ticket) => (
+              <tr key={ticket.id}>
+                <td>
+                  <Link to={`/tickets/${ticket.id}`}>{ticket.ticketNumber}</Link>
+                </td>
+                <td>{formatDate(ticket.createdAt)}</td>
+                <td>{ticket.summary}</td>
+                <td>{ticket.category.name}</td>
+                <td>{ticket.relatedSystem.name}</td>
+                <td>
+                  <PriorityBadge priority={ticket.requestedPriority} />
+                </td>
+                <td>
+                  <StatusBadge status={ticket.currentStatus} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Mobile */}
+      <ul className="list-unstyled d-md-none mb-0">
+        {tickets.map((ticket) => (
+          <li key={ticket.id} className="zen-card p-3 mb-3">
+            <div className="d-flex justify-content-between align-items-start gap-2 mb-2">
+              <Link to={`/tickets/${ticket.id}`} className="fw-semibold">
+                {ticket.ticketNumber}
+              </Link>
+              <span className="zen-muted" style={{ fontSize: "0.875rem" }}>
+                {formatDate(ticket.createdAt)}
+              </span>
+            </div>
+            <p className="mb-2">{ticket.summary}</p>
+            <p className="zen-muted mb-2" style={{ fontSize: "0.875rem" }}>
+              {ticket.category.name} · {ticket.relatedSystem.name}
+            </p>
+            <div className="d-flex flex-wrap gap-2">
+              <PriorityBadge priority={ticket.requestedPriority} />
+              <StatusBadge status={ticket.currentStatus} />
+            </div>
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+}

--- a/client/src/hooks/useDebouncedValue.ts
+++ b/client/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Delays a value so typing in the search box does not issue one request per
+ * keystroke.
+ */
+export function useDebouncedValue<T>(value: T, delayMs = 300): T {
+  const [debounced, setDebounced] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delayMs);
+    return () => clearTimeout(timer);
+  }, [value, delayMs]);
+
+  return debounced;
+}

--- a/client/src/pages/MyTicketsPage.tsx
+++ b/client/src/pages/MyTicketsPage.tsx
@@ -1,0 +1,278 @@
+import { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { fetchCategories, fetchRelatedSystems } from "../api/referenceData.js";
+import { fetchMyTickets } from "../api/tickets.js";
+import type { TicketSortField } from "../api/tickets.js";
+import { Pagination } from "../components/Pagination.js";
+import { StateBlock } from "../components/StateBlock.js";
+import { TicketList } from "../components/TicketList.js";
+import { useDebouncedValue } from "../hooks/useDebouncedValue.js";
+import type { PagedResult, Priority, ReferenceItem, TicketListItem } from "../types/index.js";
+
+const PRIORITIES: Priority[] = ["LOW", "MEDIUM", "HIGH", "URGENT"];
+const PAGE_SIZE = 10;
+
+interface Filters {
+  q: string;
+  categoryId: string;
+  relatedSystemId: string;
+  priority: string;
+}
+
+const NO_FILTERS: Filters = { q: "", categoryId: "", relatedSystemId: "", priority: "" };
+
+export function MyTicketsPage() {
+  const [filters, setFilters] = useState<Filters>(NO_FILTERS);
+  const [sort, setSort] = useState<TicketSortField>("createdAt");
+  const [order, setOrder] = useState<"asc" | "desc">("desc");
+  const [page, setPage] = useState(1);
+
+  const [result, setResult] = useState<PagedResult<TicketListItem> | null>(null);
+  const [state, setState] = useState<"loading" | "ready" | "error">("loading");
+  const [reload, setReload] = useState(0);
+
+  const [categories, setCategories] = useState<ReferenceItem[]>([]);
+  const [relatedSystems, setRelatedSystems] = useState<ReferenceItem[]>([]);
+
+  const debouncedQuery = useDebouncedValue(filters.q);
+
+  // Whether any filter is active decides between the empty state and the
+  // no-results state, which say different things (BR-41, BR-42).
+  const filtersActive =
+    debouncedQuery !== "" ||
+    filters.categoryId !== "" ||
+    filters.relatedSystemId !== "" ||
+    filters.priority !== "";
+
+  useEffect(() => {
+    Promise.all([fetchCategories(), fetchRelatedSystems()])
+      .then(([loadedCategories, loadedSystems]) => {
+        setCategories(loadedCategories);
+        setRelatedSystems(loadedSystems);
+      })
+      // The filter selects simply stay empty if reference data is unavailable;
+      // the list itself reports its own failure.
+      .catch(() => undefined);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setState("loading");
+
+    fetchMyTickets({
+      page,
+      pageSize: PAGE_SIZE,
+      sort,
+      order,
+      ...(debouncedQuery !== "" && { q: debouncedQuery }),
+      ...(filters.categoryId !== "" && { categoryId: Number(filters.categoryId) }),
+      ...(filters.relatedSystemId !== "" && { relatedSystemId: Number(filters.relatedSystemId) }),
+      ...(filters.priority !== "" && { priority: filters.priority as Priority }),
+    })
+      .then((paged) => {
+        if (cancelled) return;
+        setResult(paged);
+        setState("ready");
+      })
+      .catch(() => {
+        if (!cancelled) setState("error");
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    page,
+    sort,
+    order,
+    debouncedQuery,
+    filters.categoryId,
+    filters.relatedSystemId,
+    filters.priority,
+    reload,
+  ]);
+
+  function updateFilter<K extends keyof Filters>(field: K, value: Filters[K]) {
+    setFilters((previous) => ({ ...previous, [field]: value }));
+    // Any filter change invalidates the current page number: page 3 of the old
+    // result set is meaningless against the new one.
+    setPage(1);
+  }
+
+  function clearFilters() {
+    setFilters(NO_FILTERS);
+    setPage(1);
+  }
+
+  function changeSort(field: TicketSortField) {
+    if (field === sort) {
+      setOrder((current) => (current === "asc" ? "desc" : "asc"));
+    } else {
+      setSort(field);
+      setOrder("desc");
+    }
+    setPage(1);
+  }
+
+  return (
+    <>
+      <div className="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2 mb-4">
+        <div>
+          <h1 className="h3 mb-1">My Tickets</h1>
+          <p className="zen-muted mb-0">View and track all of your support requests.</p>
+        </div>
+        <div className="d-flex flex-wrap gap-2">
+          <button
+            type="button"
+            className="btn btn-outline-primary"
+            onClick={clearFilters}
+            disabled={!filtersActive}
+          >
+            Clear Filters
+          </button>
+          <Link className="btn btn-primary" to="/tickets/new">
+            Create Ticket
+          </Link>
+        </div>
+      </div>
+
+      <section className="zen-card p-3 mb-4" aria-label="Filters">
+        <div className="row g-3">
+          <div className="col-12 col-md-6 col-lg-3">
+            <label className="form-label fw-semibold" htmlFor="ticket-search">
+              Search
+            </label>
+            <input
+              id="ticket-search"
+              type="search"
+              className="form-control"
+              placeholder="Search by ticket number or summary…"
+              value={filters.q}
+              onChange={(e) => updateFilter("q", e.target.value)}
+            />
+          </div>
+
+          <div className="col-12 col-md-6 col-lg-3">
+            <label className="form-label fw-semibold" htmlFor="filter-category">
+              Category
+            </label>
+            <select
+              id="filter-category"
+              className="form-select"
+              value={filters.categoryId}
+              onChange={(e) => updateFilter("categoryId", e.target.value)}
+            >
+              <option value="">All Categories</option>
+              {categories.map((category) => (
+                <option key={category.id} value={category.id}>
+                  {category.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="col-12 col-md-6 col-lg-3">
+            <label className="form-label fw-semibold" htmlFor="filter-system">
+              Related System
+            </label>
+            <select
+              id="filter-system"
+              className="form-select"
+              value={filters.relatedSystemId}
+              onChange={(e) => updateFilter("relatedSystemId", e.target.value)}
+            >
+              <option value="">All Related Systems</option>
+              {relatedSystems.map((system) => (
+                <option key={system.id} value={system.id}>
+                  {system.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="col-12 col-md-6 col-lg-3">
+            <label className="form-label fw-semibold" htmlFor="filter-priority">
+              Requested Priority
+            </label>
+            <select
+              id="filter-priority"
+              className="form-select"
+              value={filters.priority}
+              onChange={(e) => updateFilter("priority", e.target.value)}
+            >
+              <option value="">All Priorities</option>
+              {PRIORITIES.map((priority) => (
+                <option key={priority} value={priority}>
+                  {priority.charAt(0) + priority.slice(1).toLowerCase()}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      </section>
+
+      {state === "loading" && <StateBlock kind="loading" title="Loading your tickets…" />}
+
+      {state === "error" && (
+        <StateBlock
+          kind="error"
+          title="Could not load your tickets"
+          description="The service did not respond. Your filters have been kept, so retrying repeats the same search."
+          action={
+            <button
+              type="button"
+              className="btn btn-outline-primary"
+              onClick={() => setReload((n) => n + 1)}
+            >
+              Retry
+            </button>
+          }
+        />
+      )}
+
+      {state === "ready" && result && result.total === 0 && !filtersActive && (
+        <StateBlock
+          kind="empty"
+          title="You have not created any tickets yet"
+          description="When you submit a support request it will appear here."
+          action={
+            <Link className="btn btn-primary" to="/tickets/new">
+              Create Ticket
+            </Link>
+          }
+        />
+      )}
+
+      {state === "ready" && result && result.total === 0 && filtersActive && (
+        <StateBlock
+          kind="no-results"
+          title="No tickets match your filters"
+          description="Try a different search term, or clear the filters to see all of your tickets."
+          action={
+            <button type="button" className="btn btn-outline-primary" onClick={clearFilters}>
+              Clear Filters
+            </button>
+          }
+        />
+      )}
+
+      {state === "ready" && result && result.total > 0 && (
+        <>
+          <TicketList
+            tickets={result.data}
+            sort={sort}
+            order={order}
+            onSortChange={changeSort}
+          />
+          <Pagination
+            page={result.page}
+            pageSize={result.pageSize}
+            total={result.total}
+            totalPages={result.totalPages}
+            onPageChange={setPage}
+          />
+        </>
+      )}
+    </>
+  );
+}

--- a/client/tests/lab-02/MyTickets.test.tsx
+++ b/client/tests/lab-02/MyTickets.test.tsx
@@ -1,0 +1,334 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { MyTicketsPage } from "../../src/pages/MyTicketsPage.js";
+import * as referenceData from "../../src/api/referenceData.js";
+import * as ticketsApi from "../../src/api/tickets.js";
+import type { PagedResult, TicketListItem } from "../../src/types/index.js";
+
+const CATEGORIES = [
+  { id: 1, name: "Account and Access" },
+  { id: 2, name: "Hardware" },
+];
+const SYSTEMS = [
+  { id: 1, name: "Email" },
+  { id: 8, name: "Corporate Laptop" },
+];
+
+function ticket(overrides: Partial<TicketListItem> = {}): TicketListItem {
+  return {
+    id: 1,
+    ticketNumber: "TKT-2026-000001",
+    summary: "Laptop battery drains quickly",
+    requestedPriority: "MEDIUM",
+    currentStatus: "NEW",
+    createdAt: "2026-09-01T09:14:00.000Z",
+    category: CATEGORIES[1],
+    relatedSystem: SYSTEMS[1],
+    attachmentCount: 0,
+    ...overrides,
+  };
+}
+
+function paged(data: TicketListItem[], overrides: Partial<PagedResult<TicketListItem>> = {}) {
+  return {
+    data,
+    page: 1,
+    pageSize: 10,
+    total: data.length,
+    totalPages: data.length === 0 ? 0 : 1,
+    ...overrides,
+  };
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/tickets"]}>
+      <Routes>
+        <Route path="/tickets" element={<MyTicketsPage />} />
+        <Route path="/tickets/new" element={<h1>Create Ticket</h1>} />
+        <Route path="/tickets/:id" element={<h1>Ticket detail</h1>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+/** The last query the page sent to the API. */
+function lastQuery(spy: { mock: { calls: unknown[][] } }): Partial<ticketsApi.TicketQuery> {
+  const { calls } = spy.mock;
+  return calls[calls.length - 1][0] as ticketsApi.TicketQuery;
+}
+
+beforeEach(() => {
+  vi.spyOn(referenceData, "fetchCategories").mockResolvedValue(CATEGORIES);
+  vi.spyOn(referenceData, "fetchRelatedSystems").mockResolvedValue(SYSTEMS);
+});
+
+describe("My Tickets — list", () => {
+  it("renders the tickets the server returned", async () => {
+    vi.spyOn(ticketsApi, "fetchMyTickets").mockResolvedValue(
+      paged([
+        ticket(),
+        ticket({ id: 2, ticketNumber: "TKT-2026-000002", summary: "Cannot connect to VPN" }),
+      ])
+    );
+
+    renderPage();
+
+    expect(await screen.findAllByText("TKT-2026-000001")).not.toHaveLength(0);
+    expect(screen.getAllByText("Cannot connect to VPN").length).toBeGreaterThan(0);
+  });
+
+  it("UI-15: renders priority and status as badges carrying their text", async () => {
+    vi.spyOn(ticketsApi, "fetchMyTickets").mockResolvedValue(
+      paged([ticket({ requestedPriority: "URGENT" })])
+    );
+
+    renderPage();
+
+    const badges = await screen.findAllByTestId("priority-badge");
+    // Colour carries emphasis, the label carries the meaning (AC-48).
+    expect(badges[0]).toHaveTextContent("Urgent");
+    expect(screen.getAllByTestId("status-badge")[0]).toHaveTextContent("New");
+  });
+
+  it("links each ticket to its detail screen", async () => {
+    vi.spyOn(ticketsApi, "fetchMyTickets").mockResolvedValue(paged([ticket({ id: 42 })]));
+
+    renderPage();
+
+    const links = await screen.findAllByRole("link", { name: "TKT-2026-000001" });
+    expect(links[0]).toHaveAttribute("href", "/tickets/42");
+  });
+
+  it("requests the default sort on first load", async () => {
+    const spy = vi.spyOn(ticketsApi, "fetchMyTickets").mockResolvedValue(paged([ticket()]));
+
+    renderPage();
+
+    await waitFor(() => expect(spy).toHaveBeenCalled());
+    expect(lastQuery(spy)).toMatchObject({ page: 1, pageSize: 10, sort: "createdAt", order: "desc" });
+  });
+});
+
+describe("My Tickets — states", () => {
+  it("shows a loading state while the request is in flight", async () => {
+    let resolve: (value: PagedResult<TicketListItem>) => void = () => {};
+    vi.spyOn(ticketsApi, "fetchMyTickets").mockReturnValue(
+      new Promise<PagedResult<TicketListItem>>((r) => {
+        resolve = r;
+      })
+    );
+
+    renderPage();
+
+    expect(screen.getByText(/Loading your tickets/i)).toBeInTheDocument();
+    resolve(paged([ticket()]));
+    await waitFor(() => expect(screen.queryByText(/Loading your tickets/i)).not.toBeInTheDocument());
+  });
+
+  it("UI-10: shows the empty state when the requester has no tickets at all", async () => {
+    vi.spyOn(ticketsApi, "fetchMyTickets").mockResolvedValue(paged([]));
+
+    renderPage();
+
+    expect(await screen.findByText(/have not created any tickets yet/i)).toBeInTheDocument();
+    // The empty state offers a way forward rather than a dead end.
+    expect(screen.getAllByRole("link", { name: /Create Ticket/i }).length).toBeGreaterThan(0);
+  });
+
+  it("UI-11: shows a distinct no-results state when filters match nothing", async () => {
+    const spy = vi
+      .spyOn(ticketsApi, "fetchMyTickets")
+      .mockResolvedValue(paged([ticket()]))
+      .mockResolvedValueOnce(paged([ticket()]));
+
+    renderPage();
+    await screen.findAllByText("TKT-2026-000001");
+
+    spy.mockResolvedValue(paged([]));
+    fireEvent.change(screen.getByLabelText(/^Category$/i), { target: { value: "2" } });
+
+    expect(await screen.findByText(/No tickets match your filters/i)).toBeInTheDocument();
+    // Must not tell the requester they have no tickets — they do (BR-42).
+    expect(screen.queryByText(/have not created any tickets yet/i)).not.toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: /Clear Filters/i }).length).toBeGreaterThan(0);
+  });
+
+  it("UI-11: Clear Filters restores the unfiltered list", async () => {
+    const spy = vi.spyOn(ticketsApi, "fetchMyTickets").mockResolvedValue(paged([ticket()]));
+
+    renderPage();
+    await screen.findAllByText("TKT-2026-000001");
+
+    spy.mockResolvedValue(paged([]));
+    fireEvent.change(screen.getByLabelText(/^Category$/i), { target: { value: "2" } });
+    await screen.findByText(/No tickets match your filters/i);
+
+    spy.mockResolvedValue(paged([ticket()]));
+    fireEvent.click(screen.getAllByRole("button", { name: /Clear Filters/i })[0]);
+
+    await waitFor(() => expect(lastQuery(spy).categoryId).toBeUndefined());
+    expect(await screen.findAllByText("TKT-2026-000001")).not.toHaveLength(0);
+  });
+
+  it("UI-12: shows a retryable failure state and keeps the filters set", async () => {
+    const spy = vi
+      .spyOn(ticketsApi, "fetchMyTickets")
+      .mockRejectedValue(new Error("Service unavailable"));
+
+    renderPage();
+
+    expect(await screen.findByText(/Could not load your tickets/i)).toBeInTheDocument();
+    // The internal message must not reach the requester (BR-27).
+    expect(screen.queryByText(/Service unavailable/)).not.toBeInTheDocument();
+
+    spy.mockResolvedValue(paged([ticket()]));
+    fireEvent.click(screen.getByRole("button", { name: /Retry/i }));
+
+    expect(await screen.findAllByText("TKT-2026-000001")).not.toHaveLength(0);
+  });
+});
+
+describe("My Tickets — search, filters and sorting", () => {
+  it("UI-13: sends the search term after debouncing", async () => {
+    const spy = vi.spyOn(ticketsApi, "fetchMyTickets").mockResolvedValue(paged([ticket()]));
+
+    renderPage();
+    await screen.findAllByText("TKT-2026-000001");
+
+    fireEvent.change(screen.getByLabelText(/Search/i), { target: { value: "battery" } });
+
+    await waitFor(() => expect(lastQuery(spy).q).toBe("battery"));
+  });
+
+  it("UI-13: sends each filter as its own parameter", async () => {
+    const spy = vi.spyOn(ticketsApi, "fetchMyTickets").mockResolvedValue(paged([ticket()]));
+
+    renderPage();
+    await screen.findAllByText("TKT-2026-000001");
+
+    fireEvent.change(screen.getByLabelText(/^Category$/i), { target: { value: "2" } });
+    await waitFor(() => expect(lastQuery(spy).categoryId).toBe(2));
+
+    fireEvent.change(screen.getByLabelText(/Related System/i), { target: { value: "8" } });
+    await waitFor(() => expect(lastQuery(spy).relatedSystemId).toBe(8));
+
+    fireEvent.change(screen.getByLabelText(/Requested Priority/i), { target: { value: "HIGH" } });
+    await waitFor(() => expect(lastQuery(spy).priority).toBe("HIGH"));
+  });
+
+  it("never sends a requesterId — ownership comes from the header alone", async () => {
+    const spy = vi.spyOn(ticketsApi, "fetchMyTickets").mockResolvedValue(paged([ticket()]));
+
+    renderPage();
+    await waitFor(() => expect(spy).toHaveBeenCalled());
+
+    expect(lastQuery(spy)).not.toHaveProperty("requesterId");
+  });
+
+  it("toggles the sort direction when the same column is clicked twice", async () => {
+    const spy = vi.spyOn(ticketsApi, "fetchMyTickets").mockResolvedValue(paged([ticket()]));
+
+    renderPage();
+    await screen.findAllByText("TKT-2026-000001");
+
+    // Re-queried before each click: the table re-renders between them, so a
+    // node captured earlier is detached and clicking it does nothing.
+    const header = () => screen.getByRole("button", { name: /Ticket No\./i });
+
+    fireEvent.click(header());
+    await waitFor(() => expect(lastQuery(spy)).toMatchObject({ sort: "ticketNumber", order: "desc" }));
+
+    fireEvent.click(header());
+    await waitFor(() => expect(lastQuery(spy)).toMatchObject({ sort: "ticketNumber", order: "asc" }));
+  });
+
+  it("exposes the sorted column through aria-sort", async () => {
+    vi.spyOn(ticketsApi, "fetchMyTickets").mockResolvedValue(paged([ticket()]));
+
+    renderPage();
+    await screen.findAllByText("TKT-2026-000001");
+
+    const createdHeader = screen.getByRole("columnheader", { name: /Created Date/i });
+    expect(createdHeader).toHaveAttribute("aria-sort", "descending");
+  });
+
+  it("returns to page 1 when a filter changes", async () => {
+    const spy = vi
+      .spyOn(ticketsApi, "fetchMyTickets")
+      .mockResolvedValue(paged([ticket()], { page: 2, total: 25, totalPages: 3 }));
+
+    renderPage();
+    await screen.findAllByText("TKT-2026-000001");
+
+    fireEvent.click(screen.getByRole("button", { name: "3" }));
+    await waitFor(() => expect(lastQuery(spy).page).toBe(3));
+
+    // Page 3 of the previous result set means nothing against a new filter.
+    fireEvent.change(screen.getByLabelText(/^Category$/i), { target: { value: "2" } });
+    await waitFor(() => expect(lastQuery(spy).page).toBe(1));
+  });
+});
+
+describe("My Tickets — pagination", () => {
+  it("UI-14: reports the visible range and the total", async () => {
+    vi.spyOn(ticketsApi, "fetchMyTickets").mockResolvedValue(
+      paged([ticket()], { page: 2, pageSize: 10, total: 25, totalPages: 3 })
+    );
+
+    renderPage();
+
+    // Page 2 of 10 covers items 11 to 20 of 25.
+    expect(await screen.findByTestId("pagination-summary")).toHaveTextContent(
+      "Showing 11 to 20 of 25 tickets"
+    );
+  });
+
+  it("UI-14: caps the range at the total on the last page", async () => {
+    vi.spyOn(ticketsApi, "fetchMyTickets").mockResolvedValue(
+      paged([ticket()], { page: 3, pageSize: 10, total: 25, totalPages: 3 })
+    );
+
+    renderPage();
+
+    expect(await screen.findByTestId("pagination-summary")).toHaveTextContent(
+      "Showing 21 to 25 of 25 tickets"
+    );
+  });
+
+  it("UI-14: requests the page the requester selected", async () => {
+    const spy = vi
+      .spyOn(ticketsApi, "fetchMyTickets")
+      .mockResolvedValue(paged([ticket()], { page: 1, total: 25, totalPages: 3 }));
+
+    renderPage();
+    await screen.findAllByText("TKT-2026-000001");
+
+    fireEvent.click(screen.getByRole("button", { name: "2" }));
+
+    await waitFor(() => expect(lastQuery(spy).page).toBe(2));
+  });
+
+  it("UI-14: marks the current page for assistive technology", async () => {
+    vi.spyOn(ticketsApi, "fetchMyTickets").mockResolvedValue(
+      paged([ticket()], { page: 2, total: 25, totalPages: 3 })
+    );
+
+    renderPage();
+
+    const nav = await screen.findByRole("navigation", { name: /Ticket list pages/i });
+    expect(within(nav).getByRole("button", { name: "2" })).toHaveAttribute("aria-current", "page");
+  });
+
+  it("disables Previous on the first page and Next on the last", async () => {
+    vi.spyOn(ticketsApi, "fetchMyTickets").mockResolvedValue(
+      paged([ticket()], { page: 1, total: 5, totalPages: 1 })
+    );
+
+    renderPage();
+
+    expect(await screen.findByRole("button", { name: /Previous/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /Next/i })).toBeDisabled();
+  });
+});

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -140,12 +140,12 @@ File: `server/tests/lab-02/attachments.api.test.ts`
 | UI-07 | UI style | BR-28, ui-spec §3 | Validation placement and ARIA | Message follows its field; `aria-invalid` and `aria-describedby` set | `client/tests/lab-02/CreateTicket.test.tsx` | Pass |
 | UI-08 | UI style | ui-spec §3 | Required asterisk | Every required label carries an asterisk, and it does not replace the message | `client/tests/lab-02/CreateTicket.test.tsx` | Pass |
 | UI-09 | UI style | ui-spec §3 | Read-only field styling | Read-only fields carry the read-only class and the `readonly` attribute | `client/tests/lab-02/CreateTicket.test.tsx` | Pass |
-| UI-10 | UI | AC-25, BR-41 | Empty state | Invites creating a first ticket | `client/tests/lab-02/MyTickets.test.tsx` | Planned |
-| UI-11 | UI | AC-26, BR-42 | No-results state | Distinct wording plus a Clear Filters action | `client/tests/lab-02/MyTickets.test.tsx` | Planned |
-| UI-12 | UI | AC-27, FR-26 | List failure state | Safe message plus Retry | `client/tests/lab-02/MyTickets.test.tsx` | Planned |
-| UI-13 | UI | FR-12, FR-13 | Search and filter wiring | Changing a control issues a request with the expected parameters | `client/tests/lab-02/MyTickets.test.tsx` | Planned |
-| UI-14 | UI | FR-15 | Pagination controls | Page change requests the new page; the range and total are displayed | `client/tests/lab-02/MyTickets.test.tsx` | Planned |
-| UI-15 | UI style | ui-spec §5 | Badge consistency | Priority and status badges render text alongside colour | `client/tests/lab-02/MyTickets.test.tsx` | Planned |
+| UI-10 | UI | AC-25, BR-41 | Empty state | Invites creating a first ticket | `client/tests/lab-02/MyTickets.test.tsx` | Pass |
+| UI-11 | UI | AC-26, BR-42 | No-results state | Distinct wording plus a Clear Filters action | `client/tests/lab-02/MyTickets.test.tsx` | Pass |
+| UI-12 | UI | AC-27, FR-26 | List failure state | Safe message plus Retry | `client/tests/lab-02/MyTickets.test.tsx` | Pass |
+| UI-13 | UI | FR-12, FR-13 | Search and filter wiring | Changing a control issues a request with the expected parameters | `client/tests/lab-02/MyTickets.test.tsx` | Pass |
+| UI-14 | UI | FR-15 | Pagination controls | Page change requests the new page; the range and total are displayed | `client/tests/lab-02/MyTickets.test.tsx` | Pass |
+| UI-15 | UI style | ui-spec §5 | Badge consistency | Priority and status badges render text alongside colour | `client/tests/lab-02/MyTickets.test.tsx` | Pass |
 | UI-16 | UI | AC-29 | Detail renders read-only | Every specified field present and read-only | `client/tests/lab-02/RequesterTicketDetail.test.tsx` | Planned |
 | UI-17 | UI | AC-30, BR-45 | Out-of-scope features absent | No comments, internal notes, actions taken, IT priority, or status control | `client/tests/lab-02/RequesterTicketDetail.test.tsx` | Planned |
 | UI-18 | UI | AC-02, BR-46 | Guard without a selected requester | Redirects to the selection screen | `client/tests/lab-02/RequesterTicketDetail.test.tsx` | Pass |


### PR DESCRIPTION
Add the ticket list: a debounced search, three filters, sortable columns, and pagination reporting the visible range and the total.

Empty and no-results are separate states chosen by whether any filter is active. Collapsing them would tell a requester who has tickets that they have none, so the distinction is the point rather than a detail. Verified by merging the two branches and watching both tests fail.

Below the md breakpoint the same records render as stacked cards instead of a scrolling table, which keeps every field readable and avoids the horizontal page scroll the sprint forbids on mobile.

Changing a filter resets to page 1, since a page number from the previous result set is meaningless against a new one. Badges always carry their label, so colour signals emphasis rather than meaning, and the sorted column and the current page are exposed through aria-sort and aria-current.