### PR TITLE
Ticket Detail screen and attachment lifecycle

### DIFF
--- a/client/src/AppRouter.tsx
+++ b/client/src/AppRouter.tsx
@@ -5,6 +5,7 @@ import { StateBlock } from "./components/StateBlock.js";
 import { RequesterProvider, useRequester } from "./context/RequesterContext.js";
 import { CreateTicketPage } from "./pages/CreateTicketPage.js";
 import { MyTicketsPage } from "./pages/MyTicketsPage.js";
+import { RequesterTicketDetailPage } from "./pages/RequesterTicketDetailPage.js";
 import { NotFoundPage } from "./pages/NotFoundPage.js";
 import { SelectRequesterPage } from "./pages/SelectRequesterPage.js";
 
@@ -31,10 +32,9 @@ export function AppRoutes() {
 
       <Route element={<RequireRequester />}>
         <Route element={<AppShell />}>
-          {/* The detail screen arrives in Issue 15. */}
           <Route path="/tickets" element={<MyTicketsPage />} />
           <Route path="/tickets/new" element={<CreateTicketPage />} />
-          <Route path="/tickets/:id" element={<div />} />
+          <Route path="/tickets/:id" element={<RequesterTicketDetailPage />} />
         </Route>
       </Route>
 

--- a/client/src/api/attachments.ts
+++ b/client/src/api/attachments.ts
@@ -1,0 +1,54 @@
+import { downloadFile, request } from "../lib/http.js";
+import type { AttachmentMeta } from "../types/index.js";
+
+export const MAX_ATTACHMENT_BYTES = 5 * 1024 * 1024;
+export const MAX_ACTIVE_ATTACHMENTS = 5;
+
+const ALLOWED_EXTENSIONS = [".jpg", ".jpeg", ".png", ".webp", ".pdf"];
+const ALLOWED_MIME_TYPES = ["image/jpeg", "image/png", "image/webp", "application/pdf"];
+
+/**
+ * Mirrors the server rules so an obviously wrong file is rejected before it is
+ * uploaded. The server checks again — this is convenience, not the gate.
+ */
+export function describeFileProblem(file: File): string | null {
+  const extension = file.name.slice(file.name.lastIndexOf(".")).toLowerCase();
+
+  if (!ALLOWED_EXTENSIONS.includes(extension) || !ALLOWED_MIME_TYPES.includes(file.type)) {
+    return "Only JPG, JPEG, PNG, WEBP and PDF files are accepted.";
+  }
+  if (file.size > MAX_ATTACHMENT_BYTES) {
+    return "Each attachment must be 5 MB or smaller.";
+  }
+  return null;
+}
+
+export function uploadAttachment(ticketId: number, file: File): Promise<AttachmentMeta> {
+  const body = new FormData();
+  body.append("file", file);
+  // Content-Type is deliberately not set: the browser must add the multipart
+  // boundary itself, and setting it by hand corrupts the request.
+  return request<AttachmentMeta>(`/api/tickets/${ticketId}/attachments`, { method: "POST", body });
+}
+
+export function removeAttachment(
+  attachmentId: number,
+  removalReason: string
+): Promise<AttachmentMeta> {
+  return request<AttachmentMeta>(`/api/attachments/${attachmentId}/remove`, {
+    method: "PATCH",
+    body: JSON.stringify({ removalReason }),
+  });
+}
+
+/**
+ * Fetches the bytes and hands them to the browser. A plain link cannot be used:
+ * it could not carry the X-Requester-Id header across origins, so the download
+ * would fail the ownership check (D-06).
+ */
+export function downloadAttachment(attachment: AttachmentMeta): Promise<void> {
+  return downloadFile(
+    `/api/attachments/${attachment.id}/download`,
+    attachment.originalFilename
+  );
+}

--- a/client/src/api/tickets.ts
+++ b/client/src/api/tickets.ts
@@ -20,6 +20,10 @@ export function createTicket(payload: CreateTicketPayload): Promise<TicketDetail
   });
 }
 
+export function fetchTicket(id: number): Promise<TicketDetail> {
+  return request<TicketDetail>(`/api/tickets/${id}`);
+}
+
 export type TicketSortField = "createdAt" | "ticketNumber" | "requestedPriority" | "summary";
 
 export interface TicketQuery {

--- a/client/src/components/AttachmentSection.tsx
+++ b/client/src/components/AttachmentSection.tsx
@@ -1,0 +1,274 @@
+import { useRef, useState } from "react";
+import {
+  MAX_ACTIVE_ATTACHMENTS,
+  describeFileProblem,
+  downloadAttachment,
+  removeAttachment,
+  uploadAttachment,
+} from "../api/attachments.js";
+import { ApiError } from "../lib/http.js";
+import type { AttachmentMeta } from "../types/index.js";
+
+interface AttachmentSectionProps {
+  ticketId: number;
+  attachments: AttachmentMeta[];
+  onChanged: (attachments: AttachmentMeta[]) => void;
+}
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function formatDateTime(iso: string): string {
+  return new Date(iso).toLocaleString();
+}
+
+export function AttachmentSection({ ticketId, attachments, onChanged }: AttachmentSectionProps) {
+  const fileInput = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+
+  const [removingId, setRemovingId] = useState<number | null>(null);
+  const [removalReason, setRemovalReason] = useState("");
+  const [removalError, setRemovalError] = useState<string | null>(null);
+  const [removalPending, setRemovalPending] = useState(false);
+
+  const [downloadError, setDownloadError] = useState<string | null>(null);
+
+  // Removed attachments do not occupy a slot (BR-31).
+  const activeCount = attachments.filter((a) => !a.isRemoved).length;
+  const limitReached = activeCount >= MAX_ACTIVE_ATTACHMENTS;
+
+  async function handleFile(event: React.ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    setUploadError(null);
+    setDownloadError(null);
+
+    const problem = describeFileProblem(file);
+    if (problem) {
+      setUploadError(problem);
+      event.target.value = "";
+      return;
+    }
+
+    setUploading(true);
+    try {
+      const created = await uploadAttachment(ticketId, file);
+      onChanged([...attachments, created]);
+    } catch (error) {
+      setUploadError(
+        error instanceof ApiError
+          ? error.message
+          : "The attachment could not be uploaded. Please try again."
+      );
+    } finally {
+      setUploading(false);
+      event.target.value = "";
+    }
+  }
+
+  async function handleDownload(attachment: AttachmentMeta) {
+    setDownloadError(null);
+    try {
+      await downloadAttachment(attachment);
+    } catch (error) {
+      setDownloadError(
+        error instanceof ApiError
+          ? error.message
+          : "The attachment could not be downloaded. Please try again."
+      );
+    }
+  }
+
+  function openRemoveDialog(attachment: AttachmentMeta) {
+    setRemovingId(attachment.id);
+    setRemovalReason("");
+    setRemovalError(null);
+  }
+
+  async function confirmRemoval() {
+    if (removingId === null) return;
+
+    setRemovalPending(true);
+    setRemovalError(null);
+    try {
+      const updated = await removeAttachment(removingId, removalReason.trim());
+      onChanged(attachments.map((a) => (a.id === updated.id ? updated : a)));
+      setRemovingId(null);
+    } catch (error) {
+      setRemovalError(
+        error instanceof ApiError
+          ? error.message
+          : "The attachment could not be removed. Please try again."
+      );
+    } finally {
+      setRemovalPending(false);
+    }
+  }
+
+  const reasonValid = removalReason.trim().length >= 3 && removalReason.trim().length <= 200;
+
+  return (
+    <section className="zen-card p-3 p-md-4" aria-labelledby="attachments-heading">
+      <div className="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
+        <h2 className="h6 mb-0" id="attachments-heading">
+          Attachments ({activeCount} active of {MAX_ACTIVE_ATTACHMENTS})
+        </h2>
+
+        <div>
+          <label className="btn btn-outline-primary mb-0" htmlFor="attachment-input">
+            {uploading ? "Uploading…" : "Add attachment"}
+          </label>
+          <input
+            id="attachment-input"
+            ref={fileInput}
+            type="file"
+            className="visually-hidden"
+            accept=".jpg,.jpeg,.png,.webp,.pdf"
+            disabled={uploading || limitReached}
+            onChange={handleFile}
+          />
+        </div>
+      </div>
+
+      {limitReached && (
+        <p className="zen-warning-panel mb-3" role="status">
+          This ticket already has {MAX_ACTIVE_ATTACHMENTS} active attachments. Remove one before
+          adding another.
+        </p>
+      )}
+
+      {uploadError && (
+        <p className="zen-field-error mb-3" role="alert">
+          {uploadError}
+        </p>
+      )}
+
+      {downloadError && (
+        <p className="zen-field-error mb-3" role="alert">
+          {downloadError}
+        </p>
+      )}
+
+      {attachments.length === 0 ? (
+        <p className="zen-muted mb-0">No attachments on this ticket.</p>
+      ) : (
+        <ul className="list-unstyled mb-0">
+          {attachments.map((attachment) => (
+            <li
+              key={attachment.id}
+              className="d-flex flex-column flex-md-row justify-content-between gap-2 py-3 border-top"
+              data-testid={`attachment-${attachment.id}`}
+            >
+              <div className={attachment.isRemoved ? "zen-muted" : ""}>
+                <p className="mb-1">
+                  <span className="fw-semibold text-break">{attachment.originalFilename}</span>
+                  {attachment.isRemoved && (
+                    <span className="zen-badge zen-badge-low ms-2">Removed</span>
+                  )}
+                </p>
+                <p className="mb-0" style={{ fontSize: "0.875rem" }}>
+                  {formatSize(attachment.sizeBytes)} · {attachment.mimeType} · uploaded{" "}
+                  {formatDateTime(attachment.uploadedAt)}
+                </p>
+                {attachment.isRemoved && (
+                  <p className="mb-0" style={{ fontSize: "0.875rem" }}>
+                    Removed {attachment.removedAt ? formatDateTime(attachment.removedAt) : ""} —{" "}
+                    {attachment.removalReason}
+                  </p>
+                )}
+              </div>
+
+              {/* A removed attachment keeps its metadata but offers no way to
+                  reach its content: no download, no preview (BR-33). */}
+              {!attachment.isRemoved && (
+                <div className="d-flex gap-2 align-items-start">
+                  <button
+                    type="button"
+                    className="btn btn-sm btn-outline-primary"
+                    onClick={() => handleDownload(attachment)}
+                  >
+                    Download
+                  </button>
+                  <button
+                    type="button"
+                    className="btn btn-sm btn-outline-danger"
+                    onClick={() => openRemoveDialog(attachment)}
+                  >
+                    Remove
+                  </button>
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {removingId !== null && (
+        <div
+          className="zen-card p-3 mt-3"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="removal-heading"
+        >
+          <h3 className="h6" id="removal-heading">
+            Remove attachment
+          </h3>
+          <p className="zen-muted" style={{ fontSize: "0.875rem" }}>
+            The file stays on record as removed, with your reason, and can no longer be downloaded.
+          </p>
+
+          <label className="form-label fw-semibold" htmlFor="removal-reason">
+            Removal reason
+            <span className="zen-required" aria-hidden="true">
+              *
+            </span>
+            <span className="visually-hidden">(required)</span>
+          </label>
+          <input
+            id="removal-reason"
+            type="text"
+            className="form-control"
+            value={removalReason}
+            maxLength={200}
+            onChange={(e) => setRemovalReason(e.target.value)}
+          />
+          <p className="zen-muted mb-2" style={{ fontSize: "0.875rem" }}>
+            Between 3 and 200 characters.
+          </p>
+
+          {removalError && (
+            <p className="zen-field-error" role="alert">
+              {removalError}
+            </p>
+          )}
+
+          <div className="d-flex justify-content-end gap-2">
+            <button
+              type="button"
+              className="btn btn-outline-primary"
+              onClick={() => setRemovingId(null)}
+              disabled={removalPending}
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="btn btn-outline-danger"
+              // Stays disabled until the reason is valid, so the requester is
+              // not sent to the server only to be told the same thing (BR-34).
+              disabled={!reasonValid || removalPending}
+              onClick={confirmRemoval}
+            >
+              {removalPending ? "Removing…" : "Confirm removal"}
+            </button>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/client/src/pages/RequesterTicketDetailPage.tsx
+++ b/client/src/pages/RequesterTicketDetailPage.tsx
@@ -1,0 +1,152 @@
+import { useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import { fetchTicket } from "../api/tickets.js";
+import { AttachmentSection } from "../components/AttachmentSection.js";
+import { PriorityBadge, StatusBadge } from "../components/Badges.js";
+import { StateBlock } from "../components/StateBlock.js";
+import { ApiError } from "../lib/http.js";
+import type { AttachmentMeta, TicketDetail } from "../types/index.js";
+
+/** Read-only presentation of one ticket field (ui-spec §3). */
+function ReadOnlyField({
+  label,
+  children,
+  className = "col-12 col-md-6 col-lg-3",
+}: {
+  label: string;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={`${className} mb-3`}>
+      <span className="form-label fw-semibold d-block">{label}</span>
+      <div className="zen-readonly">{children}</div>
+    </div>
+  );
+}
+
+export function RequesterTicketDetailPage() {
+  const { id } = useParams();
+  const [ticket, setTicket] = useState<TicketDetail | null>(null);
+  const [state, setState] = useState<"loading" | "ready" | "not-found" | "error">("loading");
+  const [reload, setReload] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setState("loading");
+
+    fetchTicket(Number(id))
+      .then((loaded) => {
+        if (cancelled) return;
+        setTicket(loaded);
+        setState("ready");
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        // 404 covers both "no such ticket" and "not yours" — the server does
+        // not distinguish them, and neither does this screen (BR-13).
+        setState(error instanceof ApiError && error.status === 404 ? "not-found" : "error");
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [id, reload]);
+
+  function updateAttachments(attachments: AttachmentMeta[]) {
+    setTicket((current) => (current ? { ...current, attachments } : current));
+  }
+
+  if (state === "loading") {
+    return <StateBlock kind="loading" title="Loading ticket…" />;
+  }
+
+  if (state === "not-found") {
+    return (
+      <StateBlock
+        kind="empty"
+        title="Ticket not found"
+        description="This ticket does not exist, or it belongs to a different requester."
+        action={
+          <Link className="btn btn-outline-primary" to="/tickets">
+            Back to My Tickets
+          </Link>
+        }
+      />
+    );
+  }
+
+  if (state === "error" || !ticket) {
+    return (
+      <StateBlock
+        kind="error"
+        title="Could not load this ticket"
+        description="The service did not respond. Please try again in a moment."
+        action={
+          <button
+            type="button"
+            className="btn btn-outline-primary"
+            onClick={() => setReload((n) => n + 1)}
+          >
+            Retry
+          </button>
+        }
+      />
+    );
+  }
+
+  return (
+    <>
+      <nav aria-label="Breadcrumb" className="mb-3">
+        <ol className="breadcrumb mb-0">
+          <li className="breadcrumb-item">
+            <Link to="/tickets">My Tickets</Link>
+          </li>
+          <li className="breadcrumb-item active" aria-current="page">
+            Ticket Details
+          </li>
+        </ol>
+      </nav>
+
+      <div className="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2 mb-4">
+        <h1 className="h3 mb-0">{ticket.ticketNumber}</h1>
+        <Link className="btn btn-outline-primary" to="/tickets">
+          Back to My Tickets
+        </Link>
+      </div>
+
+      {/* Read-only throughout: nothing on this screen edits the ticket (BR-44). */}
+      <section className="zen-card p-3 p-md-4 mb-4" aria-label="Ticket information">
+        <div className="row">
+          <ReadOnlyField label="Ticket No.">{ticket.ticketNumber}</ReadOnlyField>
+          <ReadOnlyField label="Ticket Date">
+            {new Date(ticket.createdAt).toLocaleString()}
+          </ReadOnlyField>
+          <ReadOnlyField label="Category">{ticket.category.name}</ReadOnlyField>
+          <ReadOnlyField label="Related System">{ticket.relatedSystem.name}</ReadOnlyField>
+
+          <ReadOnlyField label="Requester">{ticket.requester.fullName}</ReadOnlyField>
+          <ReadOnlyField label="Requested Priority">
+            <PriorityBadge priority={ticket.requestedPriority} />
+          </ReadOnlyField>
+          <ReadOnlyField label="Current Status">
+            <StatusBadge status={ticket.currentStatus} />
+          </ReadOnlyField>
+
+          <ReadOnlyField label="Ticket Summary" className="col-12">
+            {ticket.summary}
+          </ReadOnlyField>
+          <ReadOnlyField label="Description" className="col-12">
+            <span style={{ whiteSpace: "pre-wrap" }}>{ticket.description}</span>
+          </ReadOnlyField>
+        </div>
+      </section>
+
+      <AttachmentSection
+        ticketId={ticket.id}
+        attachments={ticket.attachments}
+        onChanged={updateAttachments}
+      />
+    </>
+  );
+}

--- a/client/tests/lab-02/AttachmentSection.test.tsx
+++ b/client/tests/lab-02/AttachmentSection.test.tsx
@@ -1,0 +1,249 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { AttachmentSection } from "../../src/components/AttachmentSection.js";
+import * as attachmentsApi from "../../src/api/attachments.js";
+import { ApiError } from "../../src/lib/http.js";
+import type { AttachmentMeta } from "../../src/types/index.js";
+
+function attachment(overrides: Partial<AttachmentMeta> = {}): AttachmentMeta {
+  return {
+    id: 1,
+    originalFilename: "evidence.png",
+    mimeType: "image/png",
+    sizeBytes: 402_118,
+    uploadedAt: "2026-09-01T09:15:00.000Z",
+    isRemoved: false,
+    removedAt: null,
+    removalReason: null,
+    ...overrides,
+  };
+}
+
+function makeFile(name: string, type: string, sizeBytes = 1024): File {
+  const file = new File(["x"], name, { type });
+  // File size cannot be set through the constructor in jsdom.
+  Object.defineProperty(file, "size", { value: sizeBytes });
+  return file;
+}
+
+function renderSection(attachments: AttachmentMeta[] = []) {
+  const onChanged = vi.fn();
+  render(<AttachmentSection ticketId={42} attachments={attachments} onChanged={onChanged} />);
+  return { onChanged };
+}
+
+function selectFile(file: File) {
+  fireEvent.change(document.getElementById("attachment-input")!, { target: { files: [file] } });
+}
+
+describe("Attachments — listing", () => {
+  it("UI-19: says so explicitly when a ticket has no attachments", () => {
+    renderSection([]);
+
+    // An explicit message rather than an empty region (BR-43).
+    expect(screen.getByText(/No attachments on this ticket/i)).toBeInTheDocument();
+  });
+
+  it("shows the filename, size, type and upload time", () => {
+    renderSection([attachment()]);
+
+    expect(screen.getByText("evidence.png")).toBeInTheDocument();
+    expect(screen.getByText(/393 KB/)).toBeInTheDocument();
+    expect(screen.getByText(/image\/png/)).toBeInTheDocument();
+  });
+
+  it("counts only active attachments toward the limit", () => {
+    renderSection([
+      attachment({ id: 1 }),
+      attachment({ id: 2, isRemoved: true, removedAt: "2026-09-02T10:00:00.000Z", removalReason: "Wrong file" }),
+    ]);
+
+    expect(screen.getByText(/1 active of 5/i)).toBeInTheDocument();
+  });
+});
+
+describe("Attachments — removed presentation", () => {
+  it("UI-23: shows a removed attachment as metadata with no way to reach its content", () => {
+    renderSection([
+      attachment({
+        id: 7,
+        originalFilename: "wrong-screenshot.png",
+        isRemoved: true,
+        removedAt: "2026-09-02T10:00:00.000Z",
+        removalReason: "Uploaded the wrong screenshot",
+      }),
+    ]);
+
+    expect(screen.getByText("wrong-screenshot.png")).toBeInTheDocument();
+    expect(screen.getByText("Removed")).toBeInTheDocument();
+    expect(screen.getByText(/Uploaded the wrong screenshot/)).toBeInTheDocument();
+
+    // No download and no remove action for a removed attachment (BR-33).
+    expect(screen.queryByRole("button", { name: /Download/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^Remove$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+
+  it("keeps download and remove available for an active attachment", () => {
+    renderSection([attachment()]);
+
+    expect(screen.getByRole("button", { name: /Download/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Remove$/i })).toBeInTheDocument();
+  });
+});
+
+describe("Attachments — upload", () => {
+  it("UI-20: uploads a permitted file and reports the new attachment", async () => {
+    const created = attachment({ id: 9, originalFilename: "scan.pdf", mimeType: "application/pdf" });
+    const spy = vi.spyOn(attachmentsApi, "uploadAttachment").mockResolvedValue(created);
+    const { onChanged } = renderSection([]);
+
+    selectFile(makeFile("scan.pdf", "application/pdf"));
+
+    await waitFor(() => expect(spy).toHaveBeenCalledTimes(1));
+    expect(spy.mock.calls[0][0]).toBe(42);
+    expect(onChanged).toHaveBeenCalledWith([created]);
+  });
+
+  it("UI-21: rejects a disallowed type before any request is made", async () => {
+    const spy = vi.spyOn(attachmentsApi, "uploadAttachment");
+    renderSection([]);
+
+    selectFile(makeFile("payload.exe", "application/octet-stream"));
+
+    expect(await screen.findByText(/Only JPG, JPEG, PNG, WEBP and PDF/i)).toBeInTheDocument();
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("UI-21: rejects an oversized file before any request is made", async () => {
+    const spy = vi.spyOn(attachmentsApi, "uploadAttachment");
+    renderSection([]);
+
+    selectFile(makeFile("huge.png", "image/png", 6 * 1024 * 1024));
+
+    expect(await screen.findByText(/5 MB or smaller/i)).toBeInTheDocument();
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("UI-22: disables the input and explains once five are active", () => {
+    renderSection([1, 2, 3, 4, 5].map((id) => attachment({ id })));
+
+    expect(screen.getByText(/already has 5 active attachments/i)).toBeInTheDocument();
+    expect(document.getElementById("attachment-input")).toBeDisabled();
+  });
+
+  it("shows a safe message when the upload fails on the server", async () => {
+    vi.spyOn(attachmentsApi, "uploadAttachment").mockRejectedValue(
+      new ApiError(409, "ATTACHMENT_LIMIT_REACHED", "A ticket may have at most 5 active attachments.")
+    );
+    renderSection([]);
+
+    selectFile(makeFile("evidence.png", "image/png"));
+
+    expect(await screen.findByText(/at most 5 active attachments/i)).toBeInTheDocument();
+  });
+});
+
+describe("Attachments — download", () => {
+  it("downloads through the API layer rather than a plain link", async () => {
+    const spy = vi.spyOn(attachmentsApi, "downloadAttachment").mockResolvedValue(undefined);
+    const active = attachment();
+    renderSection([active]);
+
+    fireEvent.click(screen.getByRole("button", { name: /Download/i }));
+
+    // A plain <a href> could not carry the identity header across origins, so
+    // the action must go through the fetch-and-blob path (D-06).
+    await waitFor(() => expect(spy).toHaveBeenCalledWith(active));
+  });
+
+  it("reports a failed download without exposing internals", async () => {
+    vi.spyOn(attachmentsApi, "downloadAttachment").mockRejectedValue(
+      new Error("ECONNREFUSED 127.0.0.1:3000")
+    );
+    renderSection([attachment()]);
+
+    fireEvent.click(screen.getByRole("button", { name: /Download/i }));
+
+    expect(await screen.findByText(/could not be downloaded/i)).toBeInTheDocument();
+    expect(screen.queryByText(/ECONNREFUSED/)).not.toBeInTheDocument();
+  });
+});
+
+describe("Attachments — removal", () => {
+  it("UI-24: keeps Confirm disabled until the reason is long enough", async () => {
+    renderSection([attachment()]);
+
+    fireEvent.click(screen.getByRole("button", { name: /^Remove$/i }));
+
+    const confirm = await screen.findByRole("button", { name: /Confirm removal/i });
+    expect(confirm).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText(/Removal reason/i), { target: { value: "no" } });
+    expect(confirm).toBeDisabled();
+
+    fireEvent.change(screen.getByLabelText(/Removal reason/i), {
+      target: { value: "Uploaded the wrong screenshot" },
+    });
+    expect(confirm).toBeEnabled();
+  });
+
+  it("UI-24: treats a whitespace-only reason as empty", async () => {
+    renderSection([attachment()]);
+
+    fireEvent.click(screen.getByRole("button", { name: /^Remove$/i }));
+    fireEvent.change(await screen.findByLabelText(/Removal reason/i), {
+      target: { value: "     " },
+    });
+
+    expect(screen.getByRole("button", { name: /Confirm removal/i })).toBeDisabled();
+  });
+
+  it("sends the trimmed reason and updates the attachment in place", async () => {
+    const removed = attachment({
+      isRemoved: true,
+      removedAt: "2026-09-02T10:00:00.000Z",
+      removalReason: "Uploaded the wrong screenshot",
+    });
+    const spy = vi.spyOn(attachmentsApi, "removeAttachment").mockResolvedValue(removed);
+    const { onChanged } = renderSection([attachment()]);
+
+    fireEvent.click(screen.getByRole("button", { name: /^Remove$/i }));
+    fireEvent.change(await screen.findByLabelText(/Removal reason/i), {
+      target: { value: "  Uploaded the wrong screenshot  " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Confirm removal/i }));
+
+    await waitFor(() =>
+      expect(spy).toHaveBeenCalledWith(1, "Uploaded the wrong screenshot")
+    );
+    expect(onChanged).toHaveBeenCalledWith([removed]);
+  });
+
+  it("shows a message and keeps the dialog open when removal fails", async () => {
+    vi.spyOn(attachmentsApi, "removeAttachment").mockRejectedValue(
+      new ApiError(409, "ALREADY_REMOVED", "This attachment has already been removed.")
+    );
+    renderSection([attachment()]);
+
+    fireEvent.click(screen.getByRole("button", { name: /^Remove$/i }));
+    fireEvent.change(await screen.findByLabelText(/Removal reason/i), {
+      target: { value: "Removing this one" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Confirm removal/i }));
+
+    expect(await screen.findByText(/already been removed/i)).toBeInTheDocument();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("closes the dialog on cancel without removing anything", async () => {
+    const spy = vi.spyOn(attachmentsApi, "removeAttachment");
+    renderSection([attachment()]);
+
+    fireEvent.click(screen.getByRole("button", { name: /^Remove$/i }));
+    fireEvent.click(await screen.findByRole("button", { name: /^Cancel$/i }));
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/client/tests/lab-02/RequesterTicketDetail.test.tsx
+++ b/client/tests/lab-02/RequesterTicketDetail.test.tsx
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { RequesterTicketDetailPage } from "../../src/pages/RequesterTicketDetailPage.js";
+import * as ticketsApi from "../../src/api/tickets.js";
+import * as referenceData from "../../src/api/referenceData.js";
+import { RequesterProvider } from "../../src/context/RequesterContext.js";
+import { AppRoutes } from "../../src/AppRouter.js";
+import { ApiError } from "../../src/lib/http.js";
+import type { TicketDetail } from "../../src/types/index.js";
+
+const TICKET: TicketDetail = {
+  id: 42,
+  ticketNumber: "TKT-2026-000042",
+  summary: "Laptop battery drains quickly",
+  description: "The battery drains much faster than usual even when the system is idle.",
+  requestedPriority: "HIGH",
+  currentStatus: "NEW",
+  createdAt: "2026-09-01T09:14:00.000Z",
+  updatedAt: "2026-09-01T09:14:00.000Z",
+  category: { id: 2, name: "Hardware" },
+  relatedSystem: { id: 8, name: "Corporate Laptop" },
+  requester: {
+    id: 1,
+    fullName: "Jennifer Anderson",
+    email: "jennifer@kmutt.ac.th",
+    department: "Engineering",
+  },
+  attachments: [],
+};
+
+function renderDetail() {
+  return render(
+    <MemoryRouter initialEntries={["/tickets/42"]}>
+      <Routes>
+        <Route path="/tickets/:id" element={<RequesterTicketDetailPage />} />
+        <Route path="/tickets" element={<h1>My Tickets</h1>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("Ticket Detail — content", () => {
+  it("UI-16: shows every specified ticket field", async () => {
+    vi.spyOn(ticketsApi, "fetchTicket").mockResolvedValue(TICKET);
+
+    renderDetail();
+
+    expect(await screen.findByRole("heading", { name: "TKT-2026-000042" })).toBeInTheDocument();
+    expect(screen.getByText("Hardware")).toBeInTheDocument();
+    expect(screen.getByText("Corporate Laptop")).toBeInTheDocument();
+    expect(screen.getByText("Jennifer Anderson")).toBeInTheDocument();
+    expect(screen.getByText("Laptop battery drains quickly")).toBeInTheDocument();
+    expect(screen.getByText(/battery drains much faster/)).toBeInTheDocument();
+    expect(screen.getByTestId("priority-badge")).toHaveTextContent("High");
+    expect(screen.getByTestId("status-badge")).toHaveTextContent("New");
+  });
+
+  it("UI-16: presents the ticket read-only, with no editable control", async () => {
+    vi.spyOn(ticketsApi, "fetchTicket").mockResolvedValue(TICKET);
+
+    renderDetail();
+
+    await screen.findByRole("heading", { name: "TKT-2026-000042" });
+    // Nothing on this screen edits the ticket (BR-44). The only inputs that may
+    // appear belong to the attachment flow, which is not open here.
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+
+    const summaryField = screen.getByText("Laptop battery drains quickly");
+    expect(summaryField).toHaveClass("zen-readonly");
+  });
+
+  it("UI-17: shows none of the features that belong to later sprints", async () => {
+    vi.spyOn(ticketsApi, "fetchTicket").mockResolvedValue(TICKET);
+
+    renderDetail();
+
+    await screen.findByRole("heading", { name: "TKT-2026-000042" });
+    // Comments, internal notes, actions taken, IT priority, ticket owner and
+    // any status control are all out of scope for Lab 2 (BR-45).
+    expect(screen.queryByText(/Public Comments/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Internal Notes/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Actions Taken/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/IT Priority/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Ticket Owner/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Resolution Summary/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Resolve|Close|Reopen|Cancel ticket/i })).not
+      .toBeInTheDocument();
+  });
+
+  it("offers a way back to the list", async () => {
+    vi.spyOn(ticketsApi, "fetchTicket").mockResolvedValue(TICKET);
+
+    renderDetail();
+
+    expect(await screen.findByRole("link", { name: /Back to My Tickets/i })).toHaveAttribute(
+      "href",
+      "/tickets"
+    );
+  });
+});
+
+describe("Ticket Detail — access and failure", () => {
+  it("reports a ticket that is not the requester's as not found", async () => {
+    // The server answers 404 for both "no such ticket" and "not yours", and
+    // this screen makes no attempt to tell them apart (BR-13).
+    vi.spyOn(ticketsApi, "fetchTicket").mockRejectedValue(
+      new ApiError(404, "TICKET_NOT_FOUND", "The requested ticket does not exist.")
+    );
+
+    renderDetail();
+
+    expect(await screen.findByText(/Ticket not found/i)).toBeInTheDocument();
+    expect(screen.getByText(/belongs to a different requester/i)).toBeInTheDocument();
+  });
+
+  it("shows a retryable failure state for any other error", async () => {
+    const spy = vi
+      .spyOn(ticketsApi, "fetchTicket")
+      .mockRejectedValue(new Error("ECONNREFUSED 127.0.0.1:3000"));
+
+    renderDetail();
+
+    expect(await screen.findByText(/Could not load this ticket/i)).toBeInTheDocument();
+    expect(screen.queryByText(/ECONNREFUSED/)).not.toBeInTheDocument();
+
+    spy.mockResolvedValue(TICKET);
+    screen.getByRole("button", { name: /Retry/i }).click();
+
+    expect(await screen.findByRole("heading", { name: "TKT-2026-000042" })).toBeInTheDocument();
+  });
+
+  it("UI-18: redirects to the selector when no requester is selected", async () => {
+    vi.spyOn(referenceData, "fetchDevRequesters").mockResolvedValue([]);
+    vi.spyOn(ticketsApi, "fetchTicket").mockResolvedValue(TICKET);
+
+    render(
+      <MemoryRouter initialEntries={["/tickets/42"]}>
+        <RequesterProvider>
+          <AppRoutes />
+        </RequesterProvider>
+      </MemoryRouter>
+    );
+
+    expect(
+      await screen.findByRole("heading", { name: /Select Development Requester/i })
+    ).toBeInTheDocument();
+  });
+});

--- a/docs/lab-02/tests.md
+++ b/docs/lab-02/tests.md
@@ -146,15 +146,15 @@ File: `server/tests/lab-02/attachments.api.test.ts`
 | UI-13 | UI | FR-12, FR-13 | Search and filter wiring | Changing a control issues a request with the expected parameters | `client/tests/lab-02/MyTickets.test.tsx` | Pass |
 | UI-14 | UI | FR-15 | Pagination controls | Page change requests the new page; the range and total are displayed | `client/tests/lab-02/MyTickets.test.tsx` | Pass |
 | UI-15 | UI style | ui-spec §5 | Badge consistency | Priority and status badges render text alongside colour | `client/tests/lab-02/MyTickets.test.tsx` | Pass |
-| UI-16 | UI | AC-29 | Detail renders read-only | Every specified field present and read-only | `client/tests/lab-02/RequesterTicketDetail.test.tsx` | Planned |
-| UI-17 | UI | AC-30, BR-45 | Out-of-scope features absent | No comments, internal notes, actions taken, IT priority, or status control | `client/tests/lab-02/RequesterTicketDetail.test.tsx` | Planned |
+| UI-16 | UI | AC-29 | Detail renders read-only | Every specified field present and read-only | `client/tests/lab-02/RequesterTicketDetail.test.tsx` | Pass |
+| UI-17 | UI | AC-30, BR-45 | Out-of-scope features absent | No comments, internal notes, actions taken, IT priority, or status control | `client/tests/lab-02/RequesterTicketDetail.test.tsx` | Pass |
 | UI-18 | UI | AC-02, BR-46 | Guard without a selected requester | Redirects to the selection screen | `client/tests/lab-02/RequesterTicketDetail.test.tsx` | Pass |
-| UI-19 | UI | BR-43 | No attachments | Explicit message rather than an empty region | `client/tests/lab-02/AttachmentSection.test.tsx` | Planned |
-| UI-20 | UI | AC-32 | Upload happy path | Selected file uploads and appears in the list | `client/tests/lab-02/AttachmentSection.test.tsx` | Planned |
-| UI-21 | UI | BR-29, BR-30 | Client-side pre-checks | Oversized and wrong-type files are rejected before any request | `client/tests/lab-02/AttachmentSection.test.tsx` | Planned |
-| UI-22 | UI | BR-31 | Limit reached | Upload control disabled with an explanation at 5 active | `client/tests/lab-02/AttachmentSection.test.tsx` | Planned |
-| UI-23 | UI | BR-33, ui-spec §7.4 | Removed attachment presentation | Greyed, reason shown, **no download and no remove action** | `client/tests/lab-02/AttachmentSection.test.tsx` | Planned |
-| UI-24 | UI | BR-34 | Removal dialog | Confirm disabled until a valid reason is entered | `client/tests/lab-02/AttachmentSection.test.tsx` | Planned |
+| UI-19 | UI | BR-43 | No attachments | Explicit message rather than an empty region | `client/tests/lab-02/AttachmentSection.test.tsx` | Pass |
+| UI-20 | UI | AC-32 | Upload happy path | Selected file uploads and appears in the list | `client/tests/lab-02/AttachmentSection.test.tsx` | Pass |
+| UI-21 | UI | BR-29, BR-30 | Client-side pre-checks | Oversized and wrong-type files are rejected before any request | `client/tests/lab-02/AttachmentSection.test.tsx` | Pass |
+| UI-22 | UI | BR-31 | Limit reached | Upload control disabled with an explanation at 5 active | `client/tests/lab-02/AttachmentSection.test.tsx` | Pass |
+| UI-23 | UI | BR-33, ui-spec §7.4 | Removed attachment presentation | Greyed, reason shown, **no download and no remove action** | `client/tests/lab-02/AttachmentSection.test.tsx` | Pass |
+| UI-24 | UI | BR-34 | Removal dialog | Confirm disabled until a valid reason is entered | `client/tests/lab-02/AttachmentSection.test.tsx` | Pass |
 | UI-25 | UI | AC-03, AC-04, BR-08 | Shell and requester switching | Name displayed; switching clears the previous Requester's data | `client/tests/lab-02/AppShell.test.tsx` | Pass |
 
 ### 2.7 End-to-end and responsive


### PR DESCRIPTION
Add the read-only ticket detail and the attachment section: upload, download, and soft removal with a reason.

Downloads go through fetch and a blob URL rather than a plain link, because an anchor cannot carry the identity header across origins and the request would fail the ownership check. The object URL is revoked afterwards.

A removed attachment keeps its metadata, its reason and its removal time, but offers no download, no remove and no preview. Verified by making the actions unconditional and watching the test fail, since the sprint requires removed files to be unreachable rather than merely discouraged.

Confirm in the removal dialog stays disabled until the reason is valid, so the requester is not sent to the server only to be told the same thing, and a whitespace-only reason counts as empty.

The screen asserts the absence of comments, internal notes, actions taken, IT priority, ticket owner and any status control, all of which belong to later sprints.