### PR TITLE
Fix pagination overflowing the viewport on mobile

### DIFF
--- a/client/src/components/Pagination.tsx
+++ b/client/src/components/Pagination.tsx
@@ -16,8 +16,8 @@ export function Pagination({ page, pageSize, total, totalPages, onPageChange }: 
         Showing {first} to {last} of {total} tickets
       </p>
 
-      <nav aria-label="Ticket list pages">
-        <ul className="pagination mb-0">
+      <nav aria-label="Ticket list pages" className="zen-pagination-nav">
+        <ul className="pagination mb-0 flex-nowrap">
           <li className={`page-item ${page <= 1 ? "disabled" : ""}`}>
             <button
               type="button"

--- a/client/src/theme.css
+++ b/client/src/theme.css
@@ -112,6 +112,17 @@ body {
   --bs-pagination-active-border-color: var(--zen-primary);
 }
 
+/* A Requester with enough tickets to reach several pages produces more
+   page-link buttons than a narrow viewport can hold once each one carries
+   the 44px touch-target minimum below. Scrolling the strip itself keeps
+   every page reachable without ever scrolling the document (FR-27 / D-07). */
+.zen-pagination-nav {
+  max-width: 100%;
+  min-width: 0;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
 /* --- Surfaces ------------------------------------------------------------ */
 
 .zen-card {


### PR DESCRIPTION
Closes #41

## What broke
Re-ran the full test suite (server/client/Playwright) against `main` as a final check before the PDF submission. `E2E-05 / E2E-07: every screen is usable at desktop, tablet and mobile` failed consistently (reproduced 3x, not flaky): `/tickets` overflowed the mobile (390px) viewport by 24px.

## Root cause
`Pagination.tsx` renders one `.page-link` per page with no truncation, and each button carries a `min-width: 44px` touch-target rule added in Issue 17. The "Jennifer Anderson" test requester used throughout the E2E suite has accumulated 57 tickets across repeated runs (E2E tests, unlike the API suites, don't clean up the tickets they create), which pushed the list to 6 pages for the first time - Previous + 6 numbers + Next = 8 buttons, wider than 390px. This is a genuine UI gap, not just a test-data artifact: the component never accounted for a Requester with many tickets on a narrow screen.

## Fix
Wrap the pagination `<nav>` in its own horizontally-scrollable strip (`overflow-x: auto`, `min-width: 0`, `flex-wrap: nowrap` on the list) so the *document* never scrolls horizontally (FR-27 / D-07) while every page button - and its 44px touch target - stays reachable by scrolling the strip itself.

## Verification
- Reverted the fix, confirmed E2E-05/07 fails the same way (24px overflow) - proving the test actually catches this.
- Re-applied the fix, confirmed E2E-05/07 passes.
- Full suite green: server 81, client 77, Playwright 13 (171 total).
